### PR TITLE
'Quick start' > 'Quickstart'.

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -67,10 +67,10 @@ module.exports = {
         nav: require('./nav/en'),
         sidebar: [
           {
-            title: 'Quick start',
+            title: 'Quickstart',
             collapsable: false,
             children: [
-                '/quick-start/'
+                '/quickstart/'
             ]
           },
           {

--- a/docs/quickstart/README.md
+++ b/docs/quickstart/README.md
@@ -1,5 +1,5 @@
 ---
-title: Quick start
+title: Quickstart
 description: Get started with Web3.Storage by following through this simple workflow.
 ---
 
@@ -27,14 +27,14 @@ Now that you've got your account set up, you can create an API key. You'll need 
 1. Note down your API key.
 
     :::warning
-    Do not share you API with anyone else. This key is specific to your account.
+    Do not share your API with anyone else. This key is specific to your account.
     :::
 
 Next up, [uploading a file to Web3.Storage ↓](#upload-a-file)
 
 ## Upload a file
 
-Uploading a file to Web3.Stoage using the JavaScript client library is pretty simple:
+Uploading a file to Web3.Storage using the JavaScript client library is pretty simple:
 
 1. Authorize your session by using your API key:
 
@@ -54,7 +54,7 @@ Uploading a file to Web3.Stoage using the JavaScript client library is pretty si
     console.log("API key.");
     ```
 
-Next up, we'll take a look at how to [get and view your data from Web3.Storage ↓](#view-file)
+Next up, we'll look at how to [get and view your data from Web3.Storage ↓](#view-file)
 
 ## View your file
 
@@ -98,3 +98,4 @@ Next, take a look at how to [download your file using the JavaScript client libr
 ## Next steps
 
 Congratulations, you've just covered the basics of Web3.Storage! Take a look at the [reference API section](/reference) for more details on what else you can do with this service.
+


### PR DESCRIPTION
Apparently _quickstart_ is a valid word. So yeah, fixing that.