### PR TITLE
Address Alan's feedback from sync call

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -92,7 +92,7 @@ module.exports = {
               '/how-tos/store',
               '/how-tos/retrieve',
               '/how-tos/query',
-              '/how-tos/regenerate-api-key',
+              '/how-tos/regenerate-api-token',
             ]
           },
           {

--- a/docs/how-tos/regenerate-api-key.md
+++ b/docs/how-tos/regenerate-api-key.md
@@ -1,9 +1,0 @@
----
-title: Regenerate API key
-description: Lorem ipsum
----
-
-# Regenerate API key
-
-Lorem ipsum.
-

--- a/docs/how-tos/regenerate-api-token.md
+++ b/docs/how-tos/regenerate-api-token.md
@@ -1,0 +1,9 @@
+---
+title: Regenerate API token
+description: Lorem ipsum
+---
+
+# Regenerate API token
+
+Lorem ipsum.
+

--- a/docs/how-tos/retrieve.md
+++ b/docs/how-tos/retrieve.md
@@ -16,7 +16,7 @@ The Web3.Storage JavaScript client provides a `get` method that allows you to re
 First, you'll need to create a Web3.Storage client using an API token. See the [Quickstart page][quickstart-guide] if you don't yet have an API token.
 
 ```js
-const { Web3Storage } = require('web3.storage')
+import { Web3Storage } from 'web3.storage'
 const token = process.env.WEB3_STORAGE_TOKEN
 const client = new Web3Storage({ token })
 ```

--- a/docs/how-tos/store.md
+++ b/docs/how-tos/store.md
@@ -56,7 +56,7 @@ Once you have a `File` constructor in scope, you can prepare your files for uplo
 ```js
 const files = [
   new File(['contents-of-file-1'], 'plain-utf8.txt'),
-  new File(aBlobOrArrayBuffer, 'pic.jpeg')
+  new File([aBlobOrArrayBuffer], 'pic.jpeg')
 ]
 ```
 

--- a/docs/how-tos/store.md
+++ b/docs/how-tos/store.md
@@ -40,15 +40,14 @@ In the example above, we read the token from an environment variable called `WEB
 
 ## Preparing files for upload
 
-The client's [`put` method][reference-js-put] accepts an array of `FileLike` objects, which is an interface based on the [Web File API](https://developer.mozilla.org/en-US/docs/Web/API/File).
+The client's [`put` method][reference-js-put] accepts an array of [`File` objects](https://developer.mozilla.org/en-US/docs/Web/API/File).
 
 When running in the browser, you can use the native `File` object provided by the browser runtime. 
 
-On node.js, the `FileLike` implementation is provided by the `@web-std/file` package, which is pulled in automatically when you add `web3.storage` to your project's dependencies. To use it, you'll need to import it into your code: 
+On node.js, import `File` from the `web3.storage` package along with the `Web3Storage` object:
 
 ```js
-// for node.js only:
-const { File } = require('@web-std/file')
+import { File, Web3Storage } from 'web3.storage'
 ```
 
 Once you have a `File` constructor in scope, you can prepare your files for upload:

--- a/docs/quickstart/README.md
+++ b/docs/quickstart/README.md
@@ -9,25 +9,25 @@ The decentralized web is complicated, but it doesn't have to be! In this quick s
 
 ## Create an account
 
-You need an account to get an API key and manage your stored data. Sign up is free:
+You need an account to get an API token and manage your stored data. Sign up is free:
 
 1. Go to [web3.storage/sign-up](https://web3.storage/sign-up)
 1. Enter your information.
 1. Verify your email address by clicking the **Verify email** link in your email inbox.
 1. You're all set!
 
-Next up, [getting an API key ↓](#get-an-api-key)
+Next up, [getting an API token ↓](#get-an-api-token)
 
-## Get an API key
+## Get an API token
 
-Now that you've got your account set up, you can create an API key. You'll need an API key to interact with Web3.Storage using the JavaScript client library:
+Now that you've got your account set up, you can create an API token. You'll need an API token to interact with Web3.Storage using the JavaScript client library:
 
 1. Head to [web3.storage/sign-in](https://web3.storage/sign-in) and sign in.
-1. Click **Create API key**.
-1. Note down your API key.
+1. Click **Create API token**.
+1. Note down your API token.
 
 :::warning
-Do not share your API with anyone else. This key is specific to your account.
+Do not share your API token with anyone else. This token is specific to your account.
 :::
 
 Next up, [uploading a file to Web3.Storage ↓](#upload-a-file)
@@ -36,22 +36,22 @@ Next up, [uploading a file to Web3.Storage ↓](#upload-a-file)
 
 Uploading a file to Web3.Storage using the JavaScript client library is pretty simple:
 
-1. Authorize your session by using your API key:
+1. Authorize your session by using your API token:
 
     ```javascript
-    console.log("API key.");
+    console.log("API token.");
     ```
 
 1. Bundle your file into an object:
 
     ```javascript
-    console.log("API key.");
+    console.log("API token.");
     ```
 
 1. Send your data to Web3.Storage:
 
     ```javascript
-    console.log("API key.");
+    console.log("API token.");
     ```
 
 Next up, we'll look at how to [get and view your data from Web3.Storage ↓](#view-file)
@@ -69,28 +69,28 @@ Next, take a look at how to [download your file using the JavaScript client libr
 
 ### JavaScript client library
 
-1. Authorize your session by using your API key:
+1. Authorize your session by using your API token:
 
     ```javascript
-    console.log("API key.");
+    console.log("API token.");
     ```
 
 1. Create a request object, including the CID of the file you want to download:
 
     ```javascript
-    console.log("API key.");
+    console.log("API token.");
     ```
 
 1. Send your request to Web3.Storage:
 
     ```javascript
-    console.log("API key.");
+    console.log("API token.");
     ```
 
 1. Web3.Storage will send your a `return` object with your data:
 
     ```javascript
-    console.log("API key.");
+    console.log("API token.");
     ```
 
 1. That's it!

--- a/docs/reference/client-library.md
+++ b/docs/reference/client-library.md
@@ -7,7 +7,7 @@ description: Integrate Web3.Storage into your code using a client library for yo
 
 ## Get started
 
-To use the JavaScript client library for Web3.Storage, you must first [obtain an API key](../how-tos/regenerate-api-key.md).
+To use the JavaScript client library for Web3.Storage, you must first [obtain an API token](../how-tos/regenerate-api-key.md).
 
 The client library automatically packs your uploads into a content addressible archive (CAR) for uploading to the Web3.Storage service, which stores data as blocks prefixed with the content ID (CID) derived from the hash of the data. You can then use the CID to retrieve the file.
 


### PR DESCRIPTION
This is just a few quick fixes for things @alanshaw called out in our zoom call earlier:

- fixes the `new File([aBlobOrArrayBuffer])` example in storage howto
- imports `File` from the `web3.storage` package instead of `@web-std/file` (node only)
- converts stray `require` statements into `import`s
- replaces "API key" with "API token" to match usage on main site

