### PR TITLE
Add clipboard copy buttons to all code blocks

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -209,7 +209,8 @@ module.exports = {
     ],
     'vuepress-plugin-chunkload-redirect',
     'vuepress-plugin-ipfs',
-    'vuepress-plugin-element-tabs'
+    'vuepress-plugin-element-tabs',
+    ['vuepress-plugin-code-copy', { align: 'bottom', color: '#fff' }]
   ],
   extraWatchFiles: ['.vuepress/nav/en.js']
 }

--- a/docs/.vuepress/theme/styles/code-copy.styl
+++ b/docs/.vuepress/theme/styles/code-copy.styl
@@ -1,0 +1,14 @@
+.code-copy {
+	position: absolute;
+	right: 0;
+	bottom: 0px;
+
+	svg {
+		height: 16px;
+		width: 16px;
+	}
+
+	span {
+		right: 35px;
+	}
+}

--- a/docs/.vuepress/theme/styles/index.styl
+++ b/docs/.vuepress/theme/styles/index.styl
@@ -8,6 +8,7 @@
 @import 'sidebar';
 @import 'video';
 @import 'alert-panels';
+@import 'code-copy';
 
 /*
 	Root elements styles to force them to use 100% of the viewport

--- a/package-lock.json
+++ b/package-lock.json
@@ -14051,6 +14051,12 @@
       "integrity": "sha512-36r6XT9stybGSL9zHfFM6F+EBOF9rRDzGdNeias3AmU3AH5+DqsciMjRpHfecKXDKeVcc0PlNfG1Tf19CW5MzA==",
       "dev": true
     },
+    "vuepress-plugin-code-copy": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/vuepress-plugin-code-copy/-/vuepress-plugin-code-copy-1.0.6.tgz",
+      "integrity": "sha512-FiqwMtlb4rEsOI56O6sSkekcd3SlESxbkR2IaTIQxsMOMoalKfW5R9WlR1Pjm10v6jmU661Ex8MR11k9IzrNUg==",
+      "dev": true
+    },
     "vuepress-plugin-container": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/vuepress-plugin-container/-/vuepress-plugin-container-2.1.5.tgz",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "vuepress-plugin-canonical": "^1.0.0",
     "vuepress-plugin-chunkload-redirect": "^1.0.3",
     "vuepress-plugin-clean-urls": "^1.1.2",
+    "vuepress-plugin-code-copy": "^1.0.6",
     "vuepress-plugin-element-tabs": "^0.2.8",
     "vuepress-plugin-ipfs": "^1.0.2",
     "vuepress-plugin-robots": "^1.0.1",


### PR DESCRIPTION
This adds `vuepress-plugin-code-copy` to the project, which adds a "copy to clipboard" button to all code blocks. I stole the styles from filecoin-docs (turns out that's where I remember having this feature, not NFT school).

Closes #25 