### PR TITLE
Removes /token page reference.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -51,7 +51,7 @@ Next up, [getting an API token ↓](#get-an-api-key)
 
 Next, let's create an API token. You'll need an API token to interact with Web3.Storage using the JavaScript client library:
 
-1. Go to your [Profile page](https://web3.storage/profile) by clicking **API Tokens** → **New Token**.
+1. Go to your [Profile page](https://web3.storage/profile) and click **API Tokens** → **New Token**.
 1. Enter a descriptive name for this token:
 1. Click **Create**.
 1. Make a note of the **Key**. Click **Copy** to copy the API token to your clipboard.

--- a/docs/README.md
+++ b/docs/README.md
@@ -51,7 +51,7 @@ Next up, [getting an API token ↓](#get-an-api-key)
 
 Next, let's create an API token. You'll need an API token to interact with Web3.Storage using the JavaScript client library:
 
-1. Go to the [tokens page](https://web3.storage/tokens) by clicking **API Tokens** → **New Token**.
+1. Go to your [Profile page](https://web3.storage/profile) by clicking **API Tokens** → **New Token**.
 1. Enter a descriptive name for this token:
 1. Click **Create**.
 1. Make a note of the **Key**. Click **Copy** to copy the API token to your clipboard.


### PR DESCRIPTION
All API tokens now come from `/profile`. The `/tokens` page _will_ exist in the future, but it's gonna be for super fancy token stuff. Most people will just need to use `/profile`.