### PR TITLE
Restyle blockquotes as callouts

### DIFF
--- a/docs/.vuepress/theme/styles/index.styl
+++ b/docs/.vuepress/theme/styles/index.styl
@@ -156,3 +156,12 @@ h5 {
 tr:nth-child(2n) {
     background-color: transparent;
 }
+
+blockquote {
+	color: $headingColor;
+	border-color: $accentColor;
+	font-size: 1.3em;
+	p {
+		line-height: 1.5;
+	}
+}

--- a/docs/.vuepress/theme/styles/theme-dark.styl
+++ b/docs/.vuepress/theme/styles/theme-dark.styl
@@ -141,6 +141,11 @@
             color: $textColorDark;
         }
 
+        blockquote {
+            color: $headingColorDark;
+            border-color: $accentColorDark;
+        }
+
         // Alert panels
         .theme-default-content {
             .custom-block {

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,9 @@ title: Welcome
 description: "Web3.Storage lets you decentralizse your data storage without all the complexities of the d-web."
 ---
 
-# Better storage. <br>Better transfers. <br>Better internet.
+# Better storage. Better transfers. Better internet.
+
+> All you need to use Web3.Storage is an API token and some data — no need to wrangle with the complicated and obstructive details of data storage. Get up and running fast with this simple [quickstart guide](#quickstart).
 
 Most data on the internet is stored with one of the large data storage companies. While companies like Amazon, Google, and Microsoft make is fairly easy for developer to store their application data, their services come with a whole host of terms and restrictions about what data can be stored, when it can be access, and who actually _owns_ that data! Not to mention, these services can be incredibly expensive, and cause developers to rack up huge bills without even knowing!
 


### PR DESCRIPTION
This PR addresses @johnnymatthews' idea from https://github.com/web3-storage/docs/pull/35 by repurposing `<blockquote>` as something more visually similar to a callout. This means we can still use ordinary Markdown syntax without injecting any html.

![image](https://user-images.githubusercontent.com/1507828/126692127-ace83d55-e07f-478c-9496-109d8af749b5.png)

![image](https://user-images.githubusercontent.com/1507828/126692337-1631dee0-338a-4fa4-8079-97f47676a284.png)
