### PR TITLE
prevent code examples in table cells from line wrapping

### DIFF
--- a/docs/.vuepress/theme/styles/index.styl
+++ b/docs/.vuepress/theme/styles/index.styl
@@ -165,3 +165,7 @@ blockquote {
 		line-height: 1.5;
 	}
 }
+
+table code {
+  white-space: nowrap;
+}


### PR DESCRIPTION
This was making my eye twitch a little:

<img width="833" alt="Screen Shot 2021-07-23 at 9 28 33 AM" src="https://user-images.githubusercontent.com/678715/126789007-24ac5be9-c89f-4d5a-8b51-c8a11d9b46af.png">

I added some css to prevent line wrapping for `code` elements inside a table, to make it look like this:

<img width="828" alt="Screen Shot 2021-07-23 at 9 28 19 AM" src="https://user-images.githubusercontent.com/678715/126789104-f4da2545-0db5-454b-8e65-8a4c38de682b.png">
