### PR TITLE
Add top navbar link to main-site About page

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -68,6 +68,7 @@ module.exports = {
           }
         },
         nav: [
+          { text: 'About', link: `${MAIN_DOMAIN}/about/` },
           { text: 'Docs', link: '/' }
         ],
         sidebar: [

--- a/docs/.vuepress/theme/layouts/404.vue
+++ b/docs/.vuepress/theme/layouts/404.vue
@@ -52,6 +52,6 @@ export default {
 
 <style lang="stylus" scoped>
 .page-nosidebar {
-	background-color: $w3storage-white;
+	background-color: $contentBgColor;
 }
 </style>

--- a/docs/.vuepress/theme/styles/header.styl
+++ b/docs/.vuepress/theme/styles/header.styl
@@ -58,6 +58,10 @@ header.navbar .links {
 	border: none;
 }
 
+header.navbar .icon.outbound {
+	display: none;
+}
+
 header.navbar .links input {
 	font-family: inherit;
 	border-radius: 0;

--- a/docs/.vuepress/theme/styles/theme-dark.styl
+++ b/docs/.vuepress/theme/styles/theme-dark.styl
@@ -6,6 +6,7 @@
     body {
         background-image: url('/images/background-schematics-dark.svg') !important;
     }
+
     .theme-container {
     
         // Content
@@ -227,6 +228,11 @@
                 color: $headingColorDark;
             }
         }
+    }
+
+    .theme-container.page-nosidebar {
+        background-color: $contentBgColorDark;
+        color: $textColorDark;
     }
 
 }


### PR DESCRIPTION
Adds top navbar link to main-site About page for consistency. 

_Bonus fix: improves visual styling of 404 page in dark mode._

![image](https://user-images.githubusercontent.com/1507828/126807000-289c71ab-7275-44b1-a7de-5b513e7f68fc.png)
![image](https://user-images.githubusercontent.com/1507828/126807184-40ef9715-4413-4bc8-ae93-a86ca0fa5a9d.png)


cc @jnthnvctr 