### PR TITLE
add with-output and output tags for code blocks

### DIFF
--- a/docs/.vuepress/theme/styles/index.styl
+++ b/docs/.vuepress/theme/styles/index.styl
@@ -11,6 +11,7 @@
 @import 'alert-panels';
 @import 'code-copy';
 @import 'tabs';
+@import 'with-output';
 
 /*
 	Root elements styles to force them to use 100% of the viewport

--- a/docs/.vuepress/theme/styles/with-output.styl
+++ b/docs/.vuepress/theme/styles/with-output.styl
@@ -1,0 +1,93 @@
+
+// Usage: apply the "with-output" class to a markdown fenced code block containing some shell input. 
+// The following code block will be treated as the "output" block, and it will be styled to be joined visually with the input block.
+//
+// example markdown:
+// ```shell with-output
+// whoami
+// ```
+//
+// ```
+// root
+// ```
+//
+// The second code block (containing "root") is automatically picked up as the output block for the preceeding `with-output` block.
+// Note that your markdown needs to have both the language for syntax highlighting (e.g. "shell"), and the "with-output" class. This won't work:
+// 
+// ```with-output 
+// Vuepress complains that with-output isn't a known language.
+// ```
+//
+div.with-output {
+  
+  border-bottom-right-radius: 0px;
+  border-bottom-left-radius: 0px;
+  margin-bottom: 0px;
+
+  pre[class*="language-"] {
+    margin: 0 0;
+  }
+
+  // apply "output" styles to the first sibling div with class "language-*" following the "input" div
+  + div[class*="language-"] {
+    
+    border-top-right-radius: 0px;
+    border-top-left-radius: 0px;
+    margin-top: 0px;
+
+    pre[class*="language-"] {
+      background: lighten($codeBgColor, 10%);
+      margin: 0 0;
+    }
+
+    // add a small "output" label at the top right of the output block
+    // the "&" parent selector puts the generated element inside the div. Without it, the ::before element gets placed inside the pre element below.
+    &:before {
+      content: 'output';
+      position: absolute;
+      top: 5px;
+      right: 10px;
+      font-size: x-small;
+    }
+
+    // disable clipboard button
+    .code-copy {
+      visibility: hidden;
+    }
+  }
+}
+
+
+// Use the output class for standalone shell output (not directly joined to an input block).
+// This is useful when you want to add some explanatory text between input and output.
+// Note that you need to use a language hint and the `output` tag - you can use `text` for plain text.
+//
+// Example:
+//
+// ```bash
+// some-shell-command
+// ```
+//
+// Here's some text that explains something about the output.
+//
+// ```text output
+// Some command ouptut
+// ```
+div.output {
+    pre[class*="language-"] {
+      background: lighten($codeBgColor, 10%);
+    }
+
+    &:before {
+      content: 'output';
+      position: absolute;
+      top: 5px;
+      right: 10px;
+      font-size: x-small;
+    }
+
+    // disable clipboard button
+    .code-copy {
+      visibility: hidden;
+    }
+}


### PR DESCRIPTION
This brings in the `with-output` and `output` classes that you can use to tag markdown blocks with for special styling.

It uses the same colors for dark and light mode, but I think they play well against both backgrounds.

Dark mode:

<img width="916" alt="Screen Shot 2021-07-23 at 11 51 56 AM" src="https://user-images.githubusercontent.com/678715/126808461-6ec46b6e-643e-4d26-bbe5-dc2fac07a763.png">

Light mode:

<img width="935" alt="Screen Shot 2021-07-23 at 11 51 43 AM" src="https://user-images.githubusercontent.com/678715/126808470-5cdb699f-a01d-42b6-98c2-7f0d545d9f1c.png">
