### PR TITLE
fix: add target to simulate internal link instead of external

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -68,7 +68,7 @@ module.exports = {
           }
         },
         nav: [
-          { text: 'About', link: `${MAIN_DOMAIN}/about/` },
+          { text: 'About', link: `${MAIN_DOMAIN}/about/`, target: '_self' },
           { text: 'Docs', link: '/' }
         ],
         sidebar: [


### PR DESCRIPTION
Otherwise the about page would open on a new tab.