### PR TITLE
fix: response handling

### DIFF
--- a/docs/how-tos/retrieve.md
+++ b/docs/how-tos/retrieve.md
@@ -30,10 +30,9 @@ Once you have a client, you can call `client.get`, passing in a CID string:
 
 ```js
 const cid = 'bafybeidd2gyhagleh47qeg77xqndy2qy3yzn4vkxmk775bg2t5lpuy7pcu'
-try {
-  const res = await client.get(cid)
-} catch (err) {
-  console.error(`failed to get ${cid}: `, err)
+const res = await client.get(cid)
+if (!res.ok) {
+  throw new Error(`failed to get ${cid}`)
 }
 ```
 


### PR DESCRIPTION
When https://github.com/web3-storage/web3.storage/pull/165 is merged a new release of the client will happen and you will need to check the `res.ok` property to know if the response was successful. It will not throw.

Apologies for the last minute API change.