### PR TITLE
clean up truthiness check on status result & tweak language

### DIFF
--- a/docs/how-tos/query.md
+++ b/docs/how-tos/query.md
@@ -41,13 +41,14 @@ The client object's `status` method accepts a CID string and returns a JSON obje
 // replace with your own CID to see info about your uploads!
 const cid = 'bafybeifljln6rmvrdqu7xopiwk2bykwa25onxnvjsmlp3xdiii3opgg2gq'
 const status = await client.status(cid)
-if (status != null) {
-  console.log(status)
+console.log(status)
+if (status) {
+  // your code to do something fun with the status info here
 }
 ```
 
 ::: warning IMPORTANT 
-**Remember to check for null!** If you ask for the status of a CID that Web3.Storage doesn't know about, the `status` method will return `undefined` instead of a status object. Make sure to check that a return value exists before trying to use it.
+**Remember to check the return value!** If you ask for the status of a CID that Web3.Storage doesn't know about, the `status` method will return `undefined` instead of a status object. Make sure to check that a return value exists before trying to use it, as we're doing above with the `if (status)` conditional statement.
 :::
 
 If the given CID is valid and has been uploaded to Web3.Storage, the `status` method will return an object that looks similar to this:


### PR DESCRIPTION
This fixes up the truthiness check on the `status` return value in our query how-to as @olizilla suggests in #87.

closes #87.