### PR TITLE
use latest client version in quickstart

### DIFF
--- a/code-snippets/quickstart/package-example.json
+++ b/code-snippets/quickstart/package-example.json
@@ -1,16 +1,16 @@
 {
-  "name": "web3-storage-quickstart",
-      "version": "0.0.0",
-      "private": true,
-      "description": "Get started using web3.storage in Node.js",
-      "type": "module",
-      "scripts": {
-          "test": "echo \"Error: no test specified\" && exit 1"
-      },
-      "dependencies": {
-          "minimist": "^1.2.5",
-          "web3.storage": "^2.0.0"
-      },
-      "author": "YOUR NAME",
-      "license": "(Apache-2.0 AND MIT)"
+    "name": "web3-storage-quickstart",
+    "version": "0.0.0",
+    "private": true,
+    "description": "Get started using web3.storage in Node.js",
+    "type": "module",
+    "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+    },
+    "dependencies": {
+        "minimist": "^1.2.5",
+        "web3.storage": "^3.1.0"
+    },
+    "author": "YOUR NAME",
+    "license": "(Apache-2.0 AND MIT)"
 }

--- a/code-snippets/quickstart/package-lock.json
+++ b/code-snippets/quickstart/package-lock.json
@@ -1,16 +1,3936 @@
 {
     "name": "web3-storage-quickstart",
     "version": "0.0.0",
-    "lockfileVersion": 1,
+    "lockfileVersion": 2,
     "requires": true,
+    "packages": {
+        "": {
+            "name": "web3-storage-quickstart",
+            "version": "0.0.0",
+            "license": "(Apache-2.0 AND MIT)",
+            "dependencies": {
+                "minimist": "^1.2.5",
+                "web3.storage": "^3.1.0"
+            }
+        },
+        "node_modules/@assemblyscript/loader": {
+            "version": "0.9.4",
+            "resolved": "https://registry.npmjs.org/@assemblyscript/loader/-/loader-0.9.4.tgz",
+            "integrity": "sha512-HazVq9zwTVwGmqdwYzu7WyQ6FQVZ7SwET0KKQuKm55jD0IfUpZgN0OPIiZG3zV1iSrVYcN0bdwLRXI/VNCYsUA=="
+        },
+        "node_modules/@babel/code-frame": {
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+            "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+            "dependencies": {
+                "@babel/highlight": "^7.14.5"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-validator-identifier": {
+            "version": "7.14.8",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.8.tgz",
+            "integrity": "sha512-ZGy6/XQjllhYQrNw/3zfWRwZCTVSiBLZ9DHVZxn9n2gip/7ab8mv2TWlKPIBk26RwedCBoWdjLmn+t9na2Gcow==",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/highlight": {
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+            "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+            "dependencies": {
+                "@babel/helper-validator-identifier": "^7.14.5",
+                "chalk": "^2.0.0",
+                "js-tokens": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@ipld/car": {
+            "version": "3.1.9",
+            "resolved": "https://registry.npmjs.org/@ipld/car/-/car-3.1.9.tgz",
+            "integrity": "sha512-LNPisNrdqA79jSyb6Xg6L4/s+z37HqaGMAGgUEc2RKyraMQqI/NVy70CdIXDX1/rPojZa52zv66ETyLltztL0w==",
+            "dependencies": {
+                "@ipld/dag-cbor": "^6.0.0",
+                "@types/varint": "^6.0.0",
+                "multiformats": "^9.0.0",
+                "varint": "^6.0.0"
+            }
+        },
+        "node_modules/@ipld/dag-cbor": {
+            "version": "6.0.6",
+            "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-6.0.6.tgz",
+            "integrity": "sha512-R53eO+oZ1lWtnVop5yi98+5HOCEjdK7OszSYDjkCy5ejes12n2Mk5YOdhkGaqgrxJ4Y1zJdNs9Gj5D0QDJuIbw==",
+            "dependencies": {
+                "cborg": "^1.2.1",
+                "multiformats": "^9.0.0"
+            }
+        },
+        "node_modules/@ipld/dag-pb": {
+            "version": "2.1.5",
+            "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-2.1.5.tgz",
+            "integrity": "sha512-mdUiUZa+QFT0aPwjeU4mltrtCjl4ugxWgK5JluBV3F+mds7HANoWSuCvmK9f4qJYWEwN5xOHgZyFp3sQqSEmzw==",
+            "dependencies": {
+                "multiformats": "^9.0.0"
+            }
+        },
+        "node_modules/@multiformats/base-x": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@multiformats/base-x/-/base-x-4.0.1.tgz",
+            "integrity": "sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw=="
+        },
+        "node_modules/@protobufjs/aspromise": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+            "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
+        },
+        "node_modules/@protobufjs/base64": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+            "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+        },
+        "node_modules/@protobufjs/codegen": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+            "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+        },
+        "node_modules/@protobufjs/eventemitter": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+            "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
+        },
+        "node_modules/@protobufjs/fetch": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+            "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+            "dependencies": {
+                "@protobufjs/aspromise": "^1.1.1",
+                "@protobufjs/inquire": "^1.1.0"
+            }
+        },
+        "node_modules/@protobufjs/float": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+            "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
+        },
+        "node_modules/@protobufjs/inquire": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+            "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
+        },
+        "node_modules/@protobufjs/path": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+            "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
+        },
+        "node_modules/@protobufjs/pool": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+            "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
+        },
+        "node_modules/@protobufjs/utf8": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+            "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
+        },
+        "node_modules/@types/long": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
+            "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
+        },
+        "node_modules/@types/minimatch": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
+            "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
+        },
+        "node_modules/@types/minimist": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
+            "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
+        },
+        "node_modules/@types/node": {
+            "version": "16.4.7",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.7.tgz",
+            "integrity": "sha512-aDDY54sst8sx47CWT6QQqIZp45yURq4dic0+HCYfYNcY5Ejlb/CLmFnRLfy3wQuYafOeh3lB/DAKaqRKBtcZmA=="
+        },
+        "node_modules/@types/normalize-package-data": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
+            "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw=="
+        },
+        "node_modules/@types/retry": {
+            "version": "0.12.1",
+            "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
+            "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g=="
+        },
+        "node_modules/@types/varint": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/@types/varint/-/varint-6.0.0.tgz",
+            "integrity": "sha512-2jBazyxGl4644tvu3VAez8UA/AtrcEetT9HOeAbqZ/vAcRVL/ZDFQjSS7rkWusU5cyONQVUz+nwwrNZdMva4ow==",
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@web-std/blob": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/@web-std/blob/-/blob-2.1.2.tgz",
+            "integrity": "sha512-Twhh3jpfvi9zMKYm6MElqLLsgUoXN5aG/qGgqB6ng2kNzPIZATMwUxSMcJV3Fs3U5dTOjEVk4m8mK4RGCpclYg==",
+            "dependencies": {
+                "web-encoding": "1.1.5",
+                "web-streams-polyfill": "3.0.3"
+            }
+        },
+        "node_modules/@web-std/fetch": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@web-std/fetch/-/fetch-2.0.3.tgz",
+            "integrity": "sha512-nr/fpYs3c4dzTEm0AMKhplAezxSh8tps3ulf3yYY0pbwHHt6jA1tL9rq2zMhbkMDSI+ZPQw7o6UW6VL5YVKZJA==",
+            "dependencies": {
+                "@web-std/blob": "^2.1.0",
+                "data-uri-to-buffer": "^3.0.1",
+                "web-streams-polyfill": "^3.0.2"
+            },
+            "engines": {
+                "node": "^10.17 || >=12.3"
+            }
+        },
+        "node_modules/@web-std/file": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@web-std/file/-/file-1.1.3.tgz",
+            "integrity": "sha512-u9xv+fEjUWPbR1c7St+Jai1qYEf2to0Iy3EZdsn9x/D2DuQrBc+zsnvgHHHsbR9GA95w3yDr0CiupshUDSjdZQ==",
+            "dependencies": {
+                "@web-std/blob": "^2.1.0"
+            }
+        },
+        "node_modules/@zxing/text-encoding": {
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz",
+            "integrity": "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==",
+            "optional": true
+        },
+        "node_modules/abort-controller": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+            "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+            "dependencies": {
+                "event-target-shim": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=6.5"
+            }
+        },
+        "node_modules/ansi-styles": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "dependencies": {
+                "color-convert": "^1.9.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/any-signal": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-2.1.2.tgz",
+            "integrity": "sha512-B+rDnWasMi/eWcajPcCWSlYc7muXOrcYrqgyzcdKisl2H/WTlQ0gip1KyQfr0ZlxJdsuWCj/LWwQm7fhyhRfIQ==",
+            "dependencies": {
+                "abort-controller": "^3.0.0",
+                "native-abort-controller": "^1.0.3"
+            }
+        },
+        "node_modules/arrify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+            "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/available-typed-arrays": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.4.tgz",
+            "integrity": "sha512-SA5mXJWrId1TaQjfxUYghbqQ/hYioKmLJvPJyDuYRtXXenFNMjj4hSSt1Cf1xsuXSXrtxrVC5Ot4eU6cOtBDdA==",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+        },
+        "node_modules/base64-js": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ]
+        },
+        "node_modules/bl": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-5.0.0.tgz",
+            "integrity": "sha512-8vxFNZ0pflFfi0WXA3WQXlj6CaMEwsmh63I1CNp0q+wWv8sD0ARx1KovSQd0l2GkwrMIOyedq0EF1FxI+RCZLQ==",
+            "dependencies": {
+                "buffer": "^6.0.3",
+                "inherits": "^2.0.4",
+                "readable-stream": "^3.4.0"
+            }
+        },
+        "node_modules/blob-to-it": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/blob-to-it/-/blob-to-it-1.0.2.tgz",
+            "integrity": "sha512-yD8tikfTlUGEOSHExz4vDCIQFLaBPXIL0KcxGQt9RbwMVXBEh+jokdJyStvTXPgWrdKfwgk7RX8GPsgrYzsyng==",
+            "dependencies": {
+                "browser-readablestream-to-it": "^1.0.2"
+            }
+        },
+        "node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/browser-readablestream-to-it": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/browser-readablestream-to-it/-/browser-readablestream-to-it-1.0.2.tgz",
+            "integrity": "sha512-lv4M2Z6RKJpyJijJzBQL5MNssS7i8yedl+QkhnLCyPtgNGNSXv1KthzUnye9NlRAtBAI80X6S9i+vK09Rzjcvg=="
+        },
+        "node_modules/buffer": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+            "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "dependencies": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.2.1"
+            }
+        },
+        "node_modules/call-bind": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+            "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+            "dependencies": {
+                "function-bind": "^1.1.1",
+                "get-intrinsic": "^1.0.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/camelcase": {
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+            "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/camelcase-keys": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+            "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+            "dependencies": {
+                "camelcase": "^5.3.1",
+                "map-obj": "^4.0.0",
+                "quick-lru": "^4.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/carbites": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/carbites/-/carbites-1.0.6.tgz",
+            "integrity": "sha512-dS9IQvnrb5VIRvSTNz5Ff+mB9d2MFfi5mojtJi7Rlss79VeF190jr0sZdA7eW0CGHotvHkZaWuM6wgfD9PEFRg==",
+            "dependencies": {
+                "@ipld/car": "^3.0.1",
+                "@ipld/dag-cbor": "^6.0.3",
+                "@ipld/dag-pb": "^2.0.2",
+                "multiformats": "^9.0.4"
+            }
+        },
+        "node_modules/cborg": {
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.3.6.tgz",
+            "integrity": "sha512-PsJqI9K9uieA4dqCfVb5gzWI0EO0axzr+LCWrETc0YmzqkLQswtVeDfhJcD7pTmkSjaVlwcQ3BybT7gcmIDMFw==",
+            "bin": {
+                "cborg": "cli.js"
+            }
+        },
+        "node_modules/chalk": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+            "dependencies": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/cids": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/cids/-/cids-1.1.7.tgz",
+            "integrity": "sha512-dlh+K0hMwFAFFjWQ2ZzxOhgGVNVREPdmk8cqHFui2U4sOodcemLMxdE5Ujga4cDcDQhWfldEPThkfu6KWBt1eA==",
+            "dependencies": {
+                "multibase": "^4.0.1",
+                "multicodec": "^3.0.1",
+                "multihashes": "^4.0.1",
+                "uint8arrays": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=4.0.0",
+                "npm": ">=3.0.0"
+            }
+        },
+        "node_modules/color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "dependencies": {
+                "color-name": "1.1.3"
+            }
+        },
+        "node_modules/color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+        },
+        "node_modules/concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+        },
+        "node_modules/data-uri-to-buffer": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
+            "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==",
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/debug": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+            "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+            "dependencies": {
+                "ms": "2.1.2"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/decamelize": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/decamelize-keys": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+            "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
+            "dependencies": {
+                "decamelize": "^1.1.0",
+                "map-obj": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/decamelize-keys/node_modules/map-obj": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+            "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/define-properties": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+            "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+            "dependencies": {
+                "object-keys": "^1.0.12"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/dns-over-http-resolver": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-1.2.3.tgz",
+            "integrity": "sha512-miDiVSI6KSNbi4SVifzO/reD8rMnxgrlnkrlkugOLQpWQTe2qMdHsZp5DmfKjxNE+/T3VAAYLQUZMv9SMr6+AA==",
+            "dependencies": {
+                "debug": "^4.3.1",
+                "native-fetch": "^3.0.0",
+                "receptacle": "^1.3.2"
+            }
+        },
+        "node_modules/electron-fetch": {
+            "version": "1.7.3",
+            "resolved": "https://registry.npmjs.org/electron-fetch/-/electron-fetch-1.7.3.tgz",
+            "integrity": "sha512-1AVMaxrHXTTMqd7EK0MGWusdqNr07Rpj8Th6bG4at0oNgIi/1LBwa9CjT/0Zy+M0k/tSJPS04nFxHj0SXDVgVw==",
+            "dependencies": {
+                "encoding": "^0.1.13"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/encoding": {
+            "version": "0.1.13",
+            "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+            "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+            "dependencies": {
+                "iconv-lite": "^0.6.2"
+            }
+        },
+        "node_modules/err-code": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/err-code/-/err-code-3.0.1.tgz",
+            "integrity": "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA=="
+        },
+        "node_modules/error-ex": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+            "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+            "dependencies": {
+                "is-arrayish": "^0.2.1"
+            }
+        },
+        "node_modules/es-abstract": {
+            "version": "1.18.3",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.3.tgz",
+            "integrity": "sha512-nQIr12dxV7SSxE6r6f1l3DtAeEYdsGpps13dR0TwJg1S8gyp4ZPgy3FZcHBgbiQqnoqSTb+oC+kO4UQ0C/J8vw==",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "es-to-primitive": "^1.2.1",
+                "function-bind": "^1.1.1",
+                "get-intrinsic": "^1.1.1",
+                "has": "^1.0.3",
+                "has-symbols": "^1.0.2",
+                "is-callable": "^1.2.3",
+                "is-negative-zero": "^2.0.1",
+                "is-regex": "^1.1.3",
+                "is-string": "^1.0.6",
+                "object-inspect": "^1.10.3",
+                "object-keys": "^1.1.1",
+                "object.assign": "^4.1.2",
+                "string.prototype.trimend": "^1.0.4",
+                "string.prototype.trimstart": "^1.0.4",
+                "unbox-primitive": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/es-to-primitive": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+            "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+            "dependencies": {
+                "is-callable": "^1.1.4",
+                "is-date-object": "^1.0.1",
+                "is-symbol": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/event-target-shim": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+            "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/events": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+            "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+            "engines": {
+                "node": ">=0.8.x"
+            }
+        },
+        "node_modules/fast-fifo": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.0.0.tgz",
+            "integrity": "sha512-4VEXmjxLj7sbs8J//cn2qhRap50dGzF5n8fjay8mau+Jn4hxSeR3xPFwxMaQq/pDaq7+KQk0PAbC2+nWDkJrmQ=="
+        },
+        "node_modules/files-from-path": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/files-from-path/-/files-from-path-0.2.0.tgz",
+            "integrity": "sha512-543OAjeBvPyInmEU4+4E6J/R1jR0yfR0MUsbOHGLruYv5PtnPxOGP0rj71a5DOE3aduKkRUpo5gFxcaeJLVcJw==",
+            "dependencies": {
+                "err-code": "^3.0.1",
+                "it-glob": "^0.0.13"
+            }
+        },
+        "node_modules/find-up": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+            "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+            "dependencies": {
+                "locate-path": "^5.0.0",
+                "path-exists": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/foreach": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+            "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+        },
+        "node_modules/function-bind": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+        },
+        "node_modules/get-intrinsic": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+            "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+            "dependencies": {
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3",
+                "has-symbols": "^1.0.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-iterator": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/get-iterator/-/get-iterator-1.0.2.tgz",
+            "integrity": "sha512-v+dm9bNVfOYsY1OrhaCrmyOcYoSeVvbt+hHZ0Au+T+p1y+0Uyj9aMaGIeUTT6xdpRbWzDeYKvfOslPhggQMcsg=="
+        },
+        "node_modules/hamt-sharding": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/hamt-sharding/-/hamt-sharding-2.0.0.tgz",
+            "integrity": "sha512-h8HKkMrqX6UC7I8hYRA1BT8pSC1TV1+V9HolGyWiNKRIztMQ980vWwjWZSLPFHtUKGMtOVBSVz5lIXuvlzwlWQ==",
+            "dependencies": {
+                "sparse-array": "^1.3.1",
+                "uint8arrays": "^2.1.2"
+            },
+            "engines": {
+                "node": ">=10.0.0",
+                "npm": ">=6.0.0"
+            }
+        },
+        "node_modules/hard-rejection": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
+            "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/has": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+            "dependencies": {
+                "function-bind": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.4.0"
+            }
+        },
+        "node_modules/has-bigints": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
+            "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/has-symbols": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+            "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/hosted-git-info": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.2.tgz",
+            "integrity": "sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==",
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/iconv-lite": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/idb-keyval": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-5.1.0.tgz",
+            "integrity": "sha512-2hvhK8CZ3dG3S9Esfuq9Gxjtjdq7XLRiBVDPLe/+CzDe4X9g7Mr3peQn+/9Xz19M/Dtyjc2lEMNVxQFvV/0BtQ==",
+            "dependencies": {
+                "safari-14-idb-fix": "^1.0.4"
+            }
+        },
+        "node_modules/ieee754": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ]
+        },
+        "node_modules/indent-string": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+            "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
+        "node_modules/interface-blockstore": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/interface-blockstore/-/interface-blockstore-1.0.0.tgz",
+            "integrity": "sha512-wkBezBLWF7BuXAOljfdj0H2xWy7pW8Y5mQlv7HqI1wKcUmVVXNa9XGPAF8j/HQ1ZbjJdftISAD932Q4AFgG0zg==",
+            "dependencies": {
+                "err-code": "^3.0.1",
+                "interface-store": "^0.1.1",
+                "it-all": "^1.0.5",
+                "it-drain": "^1.0.4",
+                "it-filter": "^1.0.2",
+                "it-take": "^1.0.1",
+                "multiformats": "^9.0.4"
+            }
+        },
+        "node_modules/interface-datastore": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-4.0.2.tgz",
+            "integrity": "sha512-/XRmD7oagZMTaK25rV3WFrejLoUwxZcpgE+eNyZNYvb2jlB5P3MwJCIbetJSlVYK7yvaFmJi8s3f9VLcxJjdog==",
+            "dependencies": {
+                "err-code": "^3.0.1",
+                "interface-store": "^0.0.2",
+                "ipfs-utils": "^8.1.2",
+                "iso-random-stream": "^2.0.0",
+                "it-all": "^1.0.2",
+                "it-drain": "^1.0.1",
+                "it-filter": "^1.0.2",
+                "it-take": "^1.0.1",
+                "nanoid": "^3.0.2",
+                "uint8arrays": "^2.1.5"
+            }
+        },
+        "node_modules/interface-datastore/node_modules/interface-store": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-0.0.2.tgz",
+            "integrity": "sha512-t4c9GKXH1Vi/WxmppGyIi6iedbGo92YmLneopHmbIEIp27ep7VnrYGA6lM/rLsFo5Tj6TJgIqr3FOk8mvPgIWQ=="
+        },
+        "node_modules/interface-store": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-0.1.1.tgz",
+            "integrity": "sha512-ynnjIOybDZc0Brep3HHSa2RVlo/M5g7kuL/leui7o21EusKcLJS170vCJ8rliisc3c4jyd9ao5PthkGlBaX29g=="
+        },
+        "node_modules/ip-regex": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
+            "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/ipfs-car": {
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/ipfs-car/-/ipfs-car-0.5.3.tgz",
+            "integrity": "sha512-jQVdKeiBCGyV5J5COpBabXgTkNxLCzii/oQOeB2qfLx679e9TZ0g1egb0fEcnrbHCkS4lh1/GqeP/UTMS5MINg==",
+            "dependencies": {
+                "@ipld/car": "^3.1.4",
+                "@web-std/blob": "^2.1.1",
+                "bl": "^5.0.0",
+                "idb-keyval": "^5.0.6",
+                "interface-blockstore": "^1.0.0",
+                "ipfs-core-types": "^0.5.2",
+                "ipfs-core-utils": "^0.8.0",
+                "ipfs-unixfs-exporter": "^6.0.0",
+                "ipfs-unixfs-importer": "^8.0.0",
+                "ipfs-utils": "^8.1.0",
+                "it-all": "^1.0.5",
+                "it-last": "^1.0.5",
+                "it-pipe": "^1.1.0",
+                "meow": "^9.0.0",
+                "move-file": "^2.1.0",
+                "multiformats": "^9.3.0",
+                "stream-to-it": "^0.2.3",
+                "streaming-iterables": "^6.0.0",
+                "uint8arrays": "^2.1.5"
+            },
+            "bin": {
+                "🚘": "dist/cjs/cli/cli.js",
+                "ipfs-car": "dist/cjs/cli/cli.js"
+            }
+        },
+        "node_modules/ipfs-core-types": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/ipfs-core-types/-/ipfs-core-types-0.5.2.tgz",
+            "integrity": "sha512-DOQeL+GFGYMTlnbdtMeBzvfVnyAalSgCfPr8XUCI+FVBZZWwzkt5jZZzGDmF87HVRrMR3FuVyBKZj772mcXKyQ==",
+            "dependencies": {
+                "cids": "^1.1.6",
+                "interface-datastore": "^4.0.0",
+                "ipld-block": "^0.11.1",
+                "multiaddr": "^9.0.1",
+                "multibase": "^4.0.2"
+            }
+        },
+        "node_modules/ipfs-core-utils": {
+            "version": "0.8.3",
+            "resolved": "https://registry.npmjs.org/ipfs-core-utils/-/ipfs-core-utils-0.8.3.tgz",
+            "integrity": "sha512-PY7PkCgCtVYtNOe1C3ew1+5D9NqXqizb886R/lyGWe+KsmWtBQkQIk0ZIDwKyHGvG2KA2QQeIDzdOmzBQBJtHQ==",
+            "dependencies": {
+                "any-signal": "^2.1.2",
+                "blob-to-it": "^1.0.1",
+                "browser-readablestream-to-it": "^1.0.1",
+                "cids": "^1.1.6",
+                "err-code": "^3.0.1",
+                "ipfs-core-types": "^0.5.2",
+                "ipfs-unixfs": "^4.0.3",
+                "ipfs-utils": "^8.1.2",
+                "it-all": "^1.0.4",
+                "it-map": "^1.0.4",
+                "it-peekable": "^1.0.1",
+                "multiaddr": "^9.0.1",
+                "multiaddr-to-uri": "^7.0.0",
+                "parse-duration": "^1.0.0",
+                "timeout-abort-controller": "^1.1.1",
+                "uint8arrays": "^2.1.3"
+            }
+        },
+        "node_modules/ipfs-unixfs": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-4.0.3.tgz",
+            "integrity": "sha512-hzJ3X4vlKT8FQ3Xc4M1szaFVjsc1ZydN+E4VQ91aXxfpjFn9G2wsMo1EFdAXNq/BUnN5dgqIOMP5zRYr3DTsAw==",
+            "dependencies": {
+                "err-code": "^3.0.1",
+                "protobufjs": "^6.10.2"
+            },
+            "engines": {
+                "node": ">=14.0.0",
+                "npm": ">=7.0.0"
+            }
+        },
+        "node_modules/ipfs-unixfs-exporter": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/ipfs-unixfs-exporter/-/ipfs-unixfs-exporter-6.0.1.tgz",
+            "integrity": "sha512-lVmCIByxJV5llUHBLC/iRFLP/s07iJl0hA5oofYP6SMUOeNiyZmY6ceMQnZHaFHRlkcg2giC0qnJvO2fNhdY5w==",
+            "dependencies": {
+                "@ipld/dag-cbor": "^6.0.4",
+                "@ipld/dag-pb": "^2.0.2",
+                "err-code": "^3.0.1",
+                "hamt-sharding": "^2.0.0",
+                "interface-blockstore": "^1.0.0",
+                "ipfs-unixfs": "^5.0.0",
+                "it-last": "^1.0.5",
+                "multiformats": "^9.4.2",
+                "murmurhash3js-revisited": "^3.0.0",
+                "uint8arrays": "^2.1.7"
+            },
+            "engines": {
+                "node": ">=14.0.0",
+                "npm": ">=7.0.0"
+            }
+        },
+        "node_modules/ipfs-unixfs-exporter/node_modules/ipfs-unixfs": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-5.0.0.tgz",
+            "integrity": "sha512-6FpBtsxB/9R7o7LGmSMaIoYkWO/cK+JYcj22QYIZaiA5dlk28Dvqme18bA43A7UKEc0M8I7mwD92ZXrlhJ/C7Q==",
+            "dependencies": {
+                "err-code": "^3.0.1",
+                "protobufjs": "^6.10.2"
+            },
+            "engines": {
+                "node": ">=14.0.0",
+                "npm": ">=7.0.0"
+            }
+        },
+        "node_modules/ipfs-unixfs-importer": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/ipfs-unixfs-importer/-/ipfs-unixfs-importer-8.0.1.tgz",
+            "integrity": "sha512-k7TW6R8vMyDffl5sZeZ9JYIJslvpYtjVdF0bX8fESAOr+/L3PsqA9ZfssDjPlRqJbZz6qKqMDcx1oWUCaJ4cgA==",
+            "dependencies": {
+                "@ipld/dag-pb": "^2.0.2",
+                "bl": "^5.0.0",
+                "err-code": "^3.0.1",
+                "hamt-sharding": "^2.0.0",
+                "interface-blockstore": "^1.0.0",
+                "ipfs-unixfs": "^5.0.0",
+                "it-all": "^1.0.5",
+                "it-batch": "^1.0.8",
+                "it-first": "^1.0.6",
+                "it-parallel-batch": "^1.0.9",
+                "merge-options": "^3.0.4",
+                "multiformats": "^9.4.2",
+                "murmurhash3js-revisited": "^3.0.0",
+                "rabin-wasm": "^0.1.4",
+                "uint8arrays": "^2.1.7"
+            },
+            "engines": {
+                "node": ">=14.0.0",
+                "npm": ">=7.0.0"
+            }
+        },
+        "node_modules/ipfs-unixfs-importer/node_modules/ipfs-unixfs": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-5.0.0.tgz",
+            "integrity": "sha512-6FpBtsxB/9R7o7LGmSMaIoYkWO/cK+JYcj22QYIZaiA5dlk28Dvqme18bA43A7UKEc0M8I7mwD92ZXrlhJ/C7Q==",
+            "dependencies": {
+                "err-code": "^3.0.1",
+                "protobufjs": "^6.10.2"
+            },
+            "engines": {
+                "node": ">=14.0.0",
+                "npm": ">=7.0.0"
+            }
+        },
+        "node_modules/ipfs-utils": {
+            "version": "8.1.4",
+            "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-8.1.4.tgz",
+            "integrity": "sha512-QJjyRh4KzlkmtAOn/fOHYyjHGuG+Ows7xJGG8eiM/v325VvJhjJ1tWJobI6zrNDeFKjZcx1uNysE3MR2/dSiXQ==",
+            "dependencies": {
+                "abort-controller": "^3.0.0",
+                "any-signal": "^2.1.0",
+                "buffer": "^6.0.1",
+                "electron-fetch": "^1.7.2",
+                "err-code": "^3.0.1",
+                "is-electron": "^2.2.0",
+                "iso-url": "^1.1.5",
+                "it-glob": "~0.0.11",
+                "it-to-stream": "^1.0.0",
+                "merge-options": "^3.0.4",
+                "nanoid": "^3.1.20",
+                "native-abort-controller": "^1.0.3",
+                "native-fetch": "^3.0.0",
+                "node-fetch": "npm:@achingbrain/node-fetch@^2.6.4",
+                "react-native-fetch-api": "^2.0.0",
+                "stream-to-it": "^0.2.2"
+            }
+        },
+        "node_modules/ipld-block": {
+            "version": "0.11.1",
+            "resolved": "https://registry.npmjs.org/ipld-block/-/ipld-block-0.11.1.tgz",
+            "integrity": "sha512-sDqqLqD5qh4QzGq6ssxLHUCnH4emCf/8F8IwjQM2cjEEIEHMUj57XhNYgmGbemdYPznUhffxFGEHsruh5+HQRw==",
+            "dependencies": {
+                "cids": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=6.0.0",
+                "npm": ">=3.0.0"
+            }
+        },
+        "node_modules/is-arguments": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.0.tgz",
+            "integrity": "sha512-1Ij4lOMPl/xB5kBDn7I+b2ttPMKa8szhEIrXDuXQD/oe3HJLTLhqhgGspwgyGd6MOywBUqVvYicF72lkgDnIHg==",
+            "dependencies": {
+                "call-bind": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-arrayish": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+        },
+        "node_modules/is-bigint": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.2.tgz",
+            "integrity": "sha512-0JV5+SOCQkIdzjBK9buARcV804Ddu7A0Qet6sHi3FimE9ne6m4BGQZfRn+NZiXbBk4F4XmHfDZIipLj9pX8dSA==",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-boolean-object": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.1.tgz",
+            "integrity": "sha512-bXdQWkECBUIAcCkeH1unwJLIpZYaa5VvuygSyS/c2lf719mTKZDU5UdDRlpd01UjADgmW8RfqaP+mRaVPdr/Ng==",
+            "dependencies": {
+                "call-bind": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-callable": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+            "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-core-module": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.5.0.tgz",
+            "integrity": "sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==",
+            "dependencies": {
+                "has": "^1.0.3"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-date-object": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.4.tgz",
+            "integrity": "sha512-/b4ZVsG7Z5XVtIxs/h9W8nvfLgSAyKYdtGWQLbqy6jA1icmgjf8WCoTKgeS4wy5tYaPePouzFMANbnj94c2Z+A==",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-electron": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.0.tgz",
+            "integrity": "sha512-SpMppC2XR3YdxSzczXReBjqs2zGscWQpBIKqwXYBFic0ERaxNVgwLCHwOLZeESfdJQjX0RDvrJ1lBXX2ij+G1Q=="
+        },
+        "node_modules/is-generator-function": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.9.tgz",
+            "integrity": "sha512-ZJ34p1uvIfptHCN7sFTjGibB9/oBg17sHqzDLfuwhvmN/qLVvIQXRQ8licZQ35WJ8KuEQt/etnnzQFI9C9Ue/A==",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-ip": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
+            "integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
+            "dependencies": {
+                "ip-regex": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/is-negative-zero": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
+            "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-number-object": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.5.tgz",
+            "integrity": "sha512-RU0lI/n95pMoUKu9v1BZP5MBcZuNSVJkMkAG2dJqC4z2GlkGUNeH68SuHuBKBD/XFe+LHZ+f9BKkLET60Niedw==",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-plain-obj": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+            "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/is-regex": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
+            "integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "has-symbols": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-string": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.6.tgz",
+            "integrity": "sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w==",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-symbol": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+            "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+            "dependencies": {
+                "has-symbols": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-typed-array": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.5.tgz",
+            "integrity": "sha512-S+GRDgJlR3PyEbsX/Fobd9cqpZBuvUS+8asRqYDMLCb2qMzt1oz5m5oxQCxOgUDxiWsOVNi4yaF+/uvdlHlYug==",
+            "dependencies": {
+                "available-typed-arrays": "^1.0.2",
+                "call-bind": "^1.0.2",
+                "es-abstract": "^1.18.0-next.2",
+                "foreach": "^2.0.5",
+                "has-symbols": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/iso-random-stream": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/iso-random-stream/-/iso-random-stream-2.0.0.tgz",
+            "integrity": "sha512-lGuIu104KfBV9ubYTSaE3GeAr6I69iggXxBHbTBc5u/XKlwlWl0LCytnkIZissaKqvxablwRD9B3ktVnmIUnEg==",
+            "dependencies": {
+                "events": "^3.3.0",
+                "readable-stream": "^3.4.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/iso-url": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-1.1.5.tgz",
+            "integrity": "sha512-+3JqoKdBTGmyv9vOkS6b9iHhvK34UajfTibrH/1HOK8TI7K2VsM0qOCd+aJdWKtSOA8g3PqZfcwDmnR0p3klqQ==",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/it-all": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/it-all/-/it-all-1.0.5.tgz",
+            "integrity": "sha512-ygD4kA4vp8fi+Y+NBgEKt6W06xSbv6Ub/0V8d1r3uCyJ9Izwa1UspkIOlqY9fOee0Z1w3WRo1+VWyAU4DgtufA=="
+        },
+        "node_modules/it-batch": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/it-batch/-/it-batch-1.0.8.tgz",
+            "integrity": "sha512-RfEa1rxOPnicXvaXJ1qNThxPrq8/Lc+KwSVWHFEEOp2CrjpjhR5WfmBJozhkbzZ/r/Gl0HjzVVrt0NpG8qczDQ=="
+        },
+        "node_modules/it-drain": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/it-drain/-/it-drain-1.0.4.tgz",
+            "integrity": "sha512-coB7mcyZ4lWBQKoQGJuqM+P94pvpn2T3KY27vcVWPqeB1WmoysRC76VZnzAqrBWzpWcoEJMjZ+fsMBslxNaWfQ=="
+        },
+        "node_modules/it-filter": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/it-filter/-/it-filter-1.0.2.tgz",
+            "integrity": "sha512-rxFUyPCrhk7WrNxD8msU10iEPhQmROoqwuyWmQUYY1PtopwUGBYyra9EYG2nRZADYeuT83cohKWmKCWPzpeyiw=="
+        },
+        "node_modules/it-first": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/it-first/-/it-first-1.0.6.tgz",
+            "integrity": "sha512-wiI02c+G1BVuu0jz30Nsr1/et0cpSRulKUusN8HDZXxuX4MdUzfMp2P4JUk+a49Wr1kHitRLrnnh3+UzJ6neaQ=="
+        },
+        "node_modules/it-glob": {
+            "version": "0.0.13",
+            "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-0.0.13.tgz",
+            "integrity": "sha512-0Hcd5BraJUPzL28NWiFbdNrcdyNxNTKKdU3sjdFiYynNTQpwlG2UKW31X7bp+XhJwux/oPzIquo5ioztVmc2RQ==",
+            "dependencies": {
+                "@types/minimatch": "^3.0.4",
+                "minimatch": "^3.0.4"
+            }
+        },
+        "node_modules/it-last": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/it-last/-/it-last-1.0.5.tgz",
+            "integrity": "sha512-PV/2S4zg5g6dkVuKfgrQfN2rUN4wdTI1FzyAvU+i8RV96syut40pa2s9Dut5X7SkjwA3P0tOhLABLdnOJ0Y/4Q=="
+        },
+        "node_modules/it-map": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/it-map/-/it-map-1.0.5.tgz",
+            "integrity": "sha512-EElupuWhHVStUgUY+OfTJIS2MZed96lDrAXzJUuqiiqLnIKoBRqtX1ZG2oR0bGDsSppmz83MtzCeKLZ9TVAUxQ=="
+        },
+        "node_modules/it-parallel-batch": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/it-parallel-batch/-/it-parallel-batch-1.0.9.tgz",
+            "integrity": "sha512-lfCxXsHoEtgyWj5HLrEQXlZF0p3c0hfYeVJAbxQIHIzHLq4lkYplUIe3UGxYl4n1Sjpcs6YL/87352399aVeIA==",
+            "dependencies": {
+                "it-batch": "^1.0.8"
+            }
+        },
+        "node_modules/it-peekable": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-1.0.2.tgz",
+            "integrity": "sha512-LRPLu94RLm+lxLZbChuc9iCXrKCOu1obWqxfaKhF00yIp30VGkl741b5P60U+rdBxuZD/Gt1bnmakernv7bVFg=="
+        },
+        "node_modules/it-pipe": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-1.1.0.tgz",
+            "integrity": "sha512-lF0/3qTVeth13TOnHVs0BTFaziwQF7m5Gg+E6JV0BXcLKutC92YjSi7bASgkPOXaLEb+YvNZrPorGMBIJvZfxg=="
+        },
+        "node_modules/it-take": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/it-take/-/it-take-1.0.1.tgz",
+            "integrity": "sha512-6H6JAWYcyumKSpcIPLs6tHN4xnibphmyU79WQaYVCBtaBOzf4fn75wzvSH8fH8fcMlPBTWY1RlmOWleQxBt2Ug=="
+        },
+        "node_modules/it-to-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/it-to-stream/-/it-to-stream-1.0.0.tgz",
+            "integrity": "sha512-pLULMZMAB/+vbdvbZtebC0nWBTbG581lk6w8P7DfIIIKUfa8FbY7Oi0FxZcFPbxvISs7A9E+cMpLDBc1XhpAOA==",
+            "dependencies": {
+                "buffer": "^6.0.3",
+                "fast-fifo": "^1.0.0",
+                "get-iterator": "^1.0.2",
+                "p-defer": "^3.0.0",
+                "p-fifo": "^1.0.0",
+                "readable-stream": "^3.6.0"
+            }
+        },
+        "node_modules/js-tokens": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+        },
+        "node_modules/json-parse-even-better-errors": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+            "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
+        },
+        "node_modules/kind-of": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+            "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/lines-and-columns": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+            "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
+        },
+        "node_modules/locate-path": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+            "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+            "dependencies": {
+                "p-locate": "^4.1.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/long": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+            "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+        },
+        "node_modules/lru-cache": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/map-obj": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.2.1.tgz",
+            "integrity": "sha512-+WA2/1sPmDj1dlvvJmB5G6JKfY9dpn7EVBUL06+y6PoljPkh+6V1QihwxNkbcGxCRjt2b0F9K0taiCuo7MbdFQ==",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/meow": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/meow/-/meow-9.0.0.tgz",
+            "integrity": "sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==",
+            "dependencies": {
+                "@types/minimist": "^1.2.0",
+                "camelcase-keys": "^6.2.2",
+                "decamelize": "^1.2.0",
+                "decamelize-keys": "^1.1.0",
+                "hard-rejection": "^2.1.0",
+                "minimist-options": "4.1.0",
+                "normalize-package-data": "^3.0.0",
+                "read-pkg-up": "^7.0.1",
+                "redent": "^3.0.0",
+                "trim-newlines": "^3.0.0",
+                "type-fest": "^0.18.0",
+                "yargs-parser": "^20.2.3"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/merge-options": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+            "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+            "dependencies": {
+                "is-plain-obj": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/min-indent": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+            "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/minimatch": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/minimist": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+        },
+        "node_modules/minimist-options": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
+            "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
+            "dependencies": {
+                "arrify": "^1.0.1",
+                "is-plain-obj": "^1.1.0",
+                "kind-of": "^6.0.3"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/minimist-options/node_modules/is-plain-obj": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+            "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/move-file": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/move-file/-/move-file-2.1.0.tgz",
+            "integrity": "sha512-i9qLW6gqboJ5Ht8bauZi7KlTnQ3QFpBCvMvFfEcHADKgHGeJ9BZMO7SFCTwHPV9Qa0du9DYY1Yx3oqlGt30nXA==",
+            "dependencies": {
+                "path-exists": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/ms": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "node_modules/multiaddr": {
+            "version": "9.0.2",
+            "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-9.0.2.tgz",
+            "integrity": "sha512-YFaEb9t4yXSbaGksSEdg+Kn2U02s7w4wXUgyEMQmPxFJj7CfVHY10WOsScAX/rK6Soa15S1zXYadqH9TtlVreQ==",
+            "dependencies": {
+                "cids": "^1.0.0",
+                "dns-over-http-resolver": "^1.0.0",
+                "err-code": "^3.0.1",
+                "is-ip": "^3.1.0",
+                "multibase": "^4.0.2",
+                "uint8arrays": "^2.1.3",
+                "varint": "^6.0.0"
+            }
+        },
+        "node_modules/multiaddr-to-uri": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/multiaddr-to-uri/-/multiaddr-to-uri-7.0.0.tgz",
+            "integrity": "sha512-VbscDpLcbV0m25tJqfnZSfbjVUuNlPa4BbD5l/7me1t0lc3SWI0XAoO5E/PNJF0e1qUlbdq7yjVFEQjUT+9r0g==",
+            "dependencies": {
+                "multiaddr": "^9.0.1"
+            }
+        },
+        "node_modules/multibase": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/multibase/-/multibase-4.0.4.tgz",
+            "integrity": "sha512-8/JmrdSGzlw6KTgAJCOqUBSGd1V6186i/X8dDCGy/lbCKrQ+1QB6f3HE+wPr7Tpdj4U3gutaj9jG2rNX6UpiJg==",
+            "dependencies": {
+                "@multiformats/base-x": "^4.0.1"
+            },
+            "engines": {
+                "node": ">=12.0.0",
+                "npm": ">=6.0.0"
+            }
+        },
+        "node_modules/multicodec": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-3.1.0.tgz",
+            "integrity": "sha512-f6d4DhbQ9a8WiJ/wpbKgeJSeR0/juP/1wnjbKdZ0KAWDkC/z7Lb3xOegMUG+uTcfwSYf6j1eTvFf8HDgqPRGmQ==",
+            "dependencies": {
+                "uint8arrays": "^2.1.5",
+                "varint": "^6.0.0"
+            }
+        },
+        "node_modules/multiformats": {
+            "version": "9.4.3",
+            "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.4.3.tgz",
+            "integrity": "sha512-sCNjBP/NPCeQu83Mst8IQZq9+HuR7Catvk/m7CeH0r/nupsU6gM7GINf5E1HCDRxDeU+Cgda/WPmcwQhYs3dyA=="
+        },
+        "node_modules/multihashes": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-4.0.2.tgz",
+            "integrity": "sha512-xpx++1iZr4ZQHjN1mcrXS6904R36LWLxX/CBifczjtmrtCXEX623DMWOF1eiNSg+pFpiZDFVBgou/4v6ayCHSQ==",
+            "dependencies": {
+                "multibase": "^4.0.1",
+                "uint8arrays": "^2.1.3",
+                "varint": "^5.0.2"
+            },
+            "engines": {
+                "node": ">=12.0.0",
+                "npm": ">=6.0.0"
+            }
+        },
+        "node_modules/multihashes/node_modules/varint": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
+            "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
+        },
+        "node_modules/murmurhash3js-revisited": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/murmurhash3js-revisited/-/murmurhash3js-revisited-3.0.0.tgz",
+            "integrity": "sha512-/sF3ee6zvScXMb1XFJ8gDsSnY+X8PbOyjIuBhtgis10W2Jx4ZjIhikUCIF9c4gpJxVnQIsPAFrSwTCuAjicP6g==",
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/nanoid": {
+            "version": "3.1.23",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
+            "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
+            "bin": {
+                "nanoid": "bin/nanoid.cjs"
+            },
+            "engines": {
+                "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+            }
+        },
+        "node_modules/native-abort-controller": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/native-abort-controller/-/native-abort-controller-1.0.3.tgz",
+            "integrity": "sha512-fd5LY5q06mHKZPD5FmMrn7Lkd2H018oBGKNOAdLpctBDEPFKsfJ1nX9ke+XRa8PEJJpjqrpQkGjq2IZ27QNmYA==",
+            "peerDependencies": {
+                "abort-controller": "*"
+            }
+        },
+        "node_modules/native-fetch": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-3.0.0.tgz",
+            "integrity": "sha512-G3Z7vx0IFb/FQ4JxvtqGABsOTIqRWvgQz6e+erkB+JJD6LrszQtMozEHI4EkmgZQvnGHrpLVzUWk7t4sJCIkVw==",
+            "peerDependencies": {
+                "node-fetch": "*"
+            }
+        },
+        "node_modules/node-fetch": {
+            "name": "@achingbrain/node-fetch",
+            "version": "2.6.7",
+            "resolved": "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz",
+            "integrity": "sha512-iTASGs+HTFK5E4ZqcMsHmeJ4zodyq8L38lZV33jwqcBJYoUt3HjN4+ot+O9/0b+ke8ddE7UgOtVuZN/OkV19/g==",
+            "engines": {
+                "node": "4.x || >=6.0.0"
+            }
+        },
+        "node_modules/normalize-package-data": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.2.tgz",
+            "integrity": "sha512-6CdZocmfGaKnIHPVFhJJZ3GuR8SsLKvDANFp47Jmy51aKIr8akjAWTSxtpI+MBgBFdSMRyo4hMpDlT6dTffgZg==",
+            "dependencies": {
+                "hosted-git-info": "^4.0.1",
+                "resolve": "^1.20.0",
+                "semver": "^7.3.4",
+                "validate-npm-package-license": "^3.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/object-inspect": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
+            "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/object-keys": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/object.assign": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+            "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+            "dependencies": {
+                "call-bind": "^1.0.0",
+                "define-properties": "^1.1.3",
+                "has-symbols": "^1.0.1",
+                "object-keys": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/p-defer": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
+            "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/p-fifo": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-fifo/-/p-fifo-1.0.0.tgz",
+            "integrity": "sha512-IjoCxXW48tqdtDFz6fqo5q1UfFVjjVZe8TC1QRflvNUJtNfCUhxOUw6MOVZhDPjqhSzc26xKdugsO17gmzd5+A==",
+            "dependencies": {
+                "fast-fifo": "^1.0.0",
+                "p-defer": "^3.0.0"
+            }
+        },
+        "node_modules/p-limit": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+            "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+            "dependencies": {
+                "p-try": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/p-locate": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+            "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+            "dependencies": {
+                "p-limit": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/p-retry": {
+            "version": "4.6.1",
+            "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.1.tgz",
+            "integrity": "sha512-e2xXGNhZOZ0lfgR9kL34iGlU8N/KO0xZnQxVEwdeOvpqNDQfdnxIYizvWtK8RglUa3bGqI8g0R/BdfzLMxRkiA==",
+            "dependencies": {
+                "@types/retry": "^0.12.0",
+                "retry": "^0.13.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/p-try": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/parse-duration": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/parse-duration/-/parse-duration-1.0.0.tgz",
+            "integrity": "sha512-X4kUkCTHU1N/kEbwK9FpUJ0UZQa90VzeczfS704frR30gljxDG0pSziws06XlK+CGRSo/1wtG1mFIdBFQTMQNw=="
+        },
+        "node_modules/parse-json": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+            "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+            "dependencies": {
+                "@babel/code-frame": "^7.0.0",
+                "error-ex": "^1.3.1",
+                "json-parse-even-better-errors": "^2.3.0",
+                "lines-and-columns": "^1.1.6"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/parse-link-header": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-1.0.1.tgz",
+            "integrity": "sha1-vt/g0hGK64S+deewJUGeyKYRQKc=",
+            "dependencies": {
+                "xtend": "~4.0.1"
+            }
+        },
+        "node_modules/path-exists": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+            "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/path-parse": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+        },
+        "node_modules/protobufjs": {
+            "version": "6.11.2",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.2.tgz",
+            "integrity": "sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==",
+            "hasInstallScript": true,
+            "dependencies": {
+                "@protobufjs/aspromise": "^1.1.2",
+                "@protobufjs/base64": "^1.1.2",
+                "@protobufjs/codegen": "^2.0.4",
+                "@protobufjs/eventemitter": "^1.1.0",
+                "@protobufjs/fetch": "^1.1.0",
+                "@protobufjs/float": "^1.0.2",
+                "@protobufjs/inquire": "^1.1.0",
+                "@protobufjs/path": "^1.1.2",
+                "@protobufjs/pool": "^1.1.0",
+                "@protobufjs/utf8": "^1.1.0",
+                "@types/long": "^4.0.1",
+                "@types/node": ">=13.7.0",
+                "long": "^4.0.0"
+            },
+            "bin": {
+                "pbjs": "bin/pbjs",
+                "pbts": "bin/pbts"
+            }
+        },
+        "node_modules/quick-lru": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+            "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/rabin-wasm": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/rabin-wasm/-/rabin-wasm-0.1.5.tgz",
+            "integrity": "sha512-uWgQTo7pim1Rnj5TuWcCewRDTf0PEFTSlaUjWP4eY9EbLV9em08v89oCz/WO+wRxpYuO36XEHp4wgYQnAgOHzA==",
+            "dependencies": {
+                "@assemblyscript/loader": "^0.9.4",
+                "bl": "^5.0.0",
+                "debug": "^4.3.1",
+                "minimist": "^1.2.5",
+                "node-fetch": "^2.6.1",
+                "readable-stream": "^3.6.0"
+            },
+            "bin": {
+                "rabin-wasm": "cli/bin.js"
+            }
+        },
+        "node_modules/react-native-fetch-api": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/react-native-fetch-api/-/react-native-fetch-api-2.0.0.tgz",
+            "integrity": "sha512-GOA8tc1EVYLnHvma/TU9VTgLOyralO7eATRuCDchQveXW9Fr9vXygyq9iwqmM7YRZ8qRJfEt9xOS7OYMdJvRFw==",
+            "dependencies": {
+                "p-defer": "^3.0.0"
+            }
+        },
+        "node_modules/read-pkg": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+            "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+            "dependencies": {
+                "@types/normalize-package-data": "^2.4.0",
+                "normalize-package-data": "^2.5.0",
+                "parse-json": "^5.0.0",
+                "type-fest": "^0.6.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/read-pkg-up": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+            "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+            "dependencies": {
+                "find-up": "^4.1.0",
+                "read-pkg": "^5.2.0",
+                "type-fest": "^0.8.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/read-pkg-up/node_modules/type-fest": {
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+            "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/read-pkg/node_modules/hosted-git-info": {
+            "version": "2.8.9",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+            "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
+        },
+        "node_modules/read-pkg/node_modules/normalize-package-data": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+            "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+            "dependencies": {
+                "hosted-git-info": "^2.1.4",
+                "resolve": "^1.10.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
+            }
+        },
+        "node_modules/read-pkg/node_modules/semver": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+            "bin": {
+                "semver": "bin/semver"
+            }
+        },
+        "node_modules/read-pkg/node_modules/type-fest": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+            "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/readable-stream": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/receptacle": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/receptacle/-/receptacle-1.3.2.tgz",
+            "integrity": "sha512-HrsFvqZZheusncQRiEE7GatOAETrARKV/lnfYicIm8lbvp/JQOdADOfhjBd2DajvoszEyxSM6RlAAIZgEoeu/A==",
+            "dependencies": {
+                "ms": "^2.1.1"
+            }
+        },
+        "node_modules/redent": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+            "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+            "dependencies": {
+                "indent-string": "^4.0.0",
+                "strip-indent": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/resolve": {
+            "version": "1.20.0",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+            "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+            "dependencies": {
+                "is-core-module": "^2.2.0",
+                "path-parse": "^1.0.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/retimer": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/retimer/-/retimer-2.0.0.tgz",
+            "integrity": "sha512-KLXY85WkEq2V2bKex/LOO1ViXVn2KGYe4PYysAdYdjmraYIUsVkXu8O4am+8+5UbaaGl1qho4aqAAPHNQ4GSbg=="
+        },
+        "node_modules/retry": {
+            "version": "0.13.1",
+            "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+            "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+            "engines": {
+                "node": ">= 4"
+            }
+        },
+        "node_modules/safari-14-idb-fix": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/safari-14-idb-fix/-/safari-14-idb-fix-1.0.4.tgz",
+            "integrity": "sha512-4+Y2baQdgJpzu84d0QjySl70Kyygzf0pepVg8NVg4NnQEPpfC91fAn0baNvtStlCjUUxxiu0BOMiafa98fRRuA=="
+        },
+        "node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ]
+        },
+        "node_modules/safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+        },
+        "node_modules/semver": {
+            "version": "7.3.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+            "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/sparse-array": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/sparse-array/-/sparse-array-1.3.2.tgz",
+            "integrity": "sha512-ZT711fePGn3+kQyLuv1fpd3rNSkNF8vd5Kv2D+qnOANeyKs3fx6bUMGWRPvgTTcYV64QMqZKZwcuaQSP3AZ0tg=="
+        },
+        "node_modules/spdx-correct": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+            "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
+            "dependencies": {
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "node_modules/spdx-exceptions": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+            "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A=="
+        },
+        "node_modules/spdx-expression-parse": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+            "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+            "dependencies": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "node_modules/spdx-license-ids": {
+            "version": "3.0.9",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.9.tgz",
+            "integrity": "sha512-Ki212dKK4ogX+xDo4CtOZBVIwhsKBEfsEEcwmJfLQzirgc2jIWdzg40Unxz/HzEUqM1WFzVlQSMF9kZZ2HboLQ=="
+        },
+        "node_modules/stream-to-it": {
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/stream-to-it/-/stream-to-it-0.2.4.tgz",
+            "integrity": "sha512-4vEbkSs83OahpmBybNJXlJd7d6/RxzkkSdT3I0mnGt79Xd2Kk+e1JqbvAvsQfCeKj3aKb0QIWkyK3/n0j506vQ==",
+            "dependencies": {
+                "get-iterator": "^1.0.2"
+            }
+        },
+        "node_modules/streaming-iterables": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/streaming-iterables/-/streaming-iterables-6.0.0.tgz",
+            "integrity": "sha512-GYbJh0ife8PvryWSyFifY1m1uj6zO12d9duuP6xltiOolUz44eKasp5gbFhRbFbLy50ik6hcKn4Pbxl9AkxB+Q==",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/string_decoder": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+            "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+            "dependencies": {
+                "safe-buffer": "~5.2.0"
+            }
+        },
+        "node_modules/string.prototype.trimend": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+            "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/string.prototype.trimstart": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+            "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/strip-indent": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+            "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+            "dependencies": {
+                "min-indent": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/supports-color": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "dependencies": {
+                "has-flag": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/timeout-abort-controller": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/timeout-abort-controller/-/timeout-abort-controller-1.1.1.tgz",
+            "integrity": "sha512-BsF9i3NAJag6T0ZEjki9j654zoafI2X6ayuNd6Tp8+Ul6Tr5s4jo973qFeiWrRSweqvskC+AHDKUmIW4b7pdhQ==",
+            "dependencies": {
+                "abort-controller": "^3.0.0",
+                "retimer": "^2.0.0"
+            }
+        },
+        "node_modules/trim-newlines": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
+            "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/type-fest": {
+            "version": "0.18.1",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
+            "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/uint8arrays": {
+            "version": "2.1.8",
+            "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-2.1.8.tgz",
+            "integrity": "sha512-qpZ/B88mSea11W3LvoimtnGWIC2i3gGuXby5wBkn8jY+OFulbaQwyjpOYSyrASqgcNEvKdAkLiOwiUt5cPSdcQ==",
+            "dependencies": {
+                "multiformats": "^9.4.2"
+            }
+        },
+        "node_modules/unbox-primitive": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
+            "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+            "dependencies": {
+                "function-bind": "^1.1.1",
+                "has-bigints": "^1.0.1",
+                "has-symbols": "^1.0.2",
+                "which-boxed-primitive": "^1.0.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/util": {
+            "version": "0.12.4",
+            "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
+            "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "is-arguments": "^1.0.4",
+                "is-generator-function": "^1.0.7",
+                "is-typed-array": "^1.1.3",
+                "safe-buffer": "^5.1.2",
+                "which-typed-array": "^1.1.2"
+            }
+        },
+        "node_modules/util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+        },
+        "node_modules/validate-npm-package-license": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+            "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+            "dependencies": {
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
+            }
+        },
+        "node_modules/varint": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
+            "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
+        },
+        "node_modules/web-encoding": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.1.5.tgz",
+            "integrity": "sha512-HYLeVCdJ0+lBYV2FvNZmv3HJ2Nt0QYXqZojk3d9FJOLkwnuhzM9tmamh8d7HPM8QqjKH8DeHkFTx+CFlWpZZDA==",
+            "dependencies": {
+                "util": "^0.12.3"
+            },
+            "optionalDependencies": {
+                "@zxing/text-encoding": "0.9.0"
+            }
+        },
+        "node_modules/web-streams-polyfill": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.0.3.tgz",
+            "integrity": "sha512-d2H/t0eqRNM4w2WvmTdoeIvzAUSpK7JmATB8Nr2lb7nQ9BTIJVjbQ/TRFVEh2gUH1HwclPdoPtfMoFfetXaZnA==",
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/web3.storage": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/web3.storage/-/web3.storage-3.1.0.tgz",
+            "integrity": "sha512-CdxoQ4WKvXQMx2Hw7MOdCUOmwSpCdtOX+XI86EbiFwldXA3KmFdwF1b/VeYpQpKHEnheoANrO/owRujj3M22FQ==",
+            "dependencies": {
+                "@ipld/car": "^3.1.4",
+                "@web-std/blob": "^2.1.0",
+                "@web-std/fetch": "^2.0.2",
+                "@web-std/file": "^1.1.0",
+                "browser-readablestream-to-it": "^1.0.2",
+                "carbites": "^1.0.6",
+                "files-from-path": "^0.2.0",
+                "ipfs-car": "^0.5.3",
+                "p-retry": "^4.5.0",
+                "parse-link-header": "^1.0.1",
+                "streaming-iterables": "^6.0.0"
+            }
+        },
+        "node_modules/which-boxed-primitive": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+            "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+            "dependencies": {
+                "is-bigint": "^1.0.1",
+                "is-boolean-object": "^1.1.0",
+                "is-number-object": "^1.0.4",
+                "is-string": "^1.0.5",
+                "is-symbol": "^1.0.3"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/which-typed-array": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.4.tgz",
+            "integrity": "sha512-49E0SpUe90cjpoc7BOJwyPHRqSAd12c10Qm2amdEZrJPCY2NDxaW01zHITrem+rnETY3dwrbH3UUrUwagfCYDA==",
+            "dependencies": {
+                "available-typed-arrays": "^1.0.2",
+                "call-bind": "^1.0.0",
+                "es-abstract": "^1.18.0-next.1",
+                "foreach": "^2.0.5",
+                "function-bind": "^1.1.1",
+                "has-symbols": "^1.0.1",
+                "is-typed-array": "^1.1.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/xtend": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+            "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+            "engines": {
+                "node": ">=0.4"
+            }
+        },
+        "node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        },
+        "node_modules/yargs-parser": {
+            "version": "20.2.9",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+            "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+            "engines": {
+                "node": ">=10"
+            }
+        }
+    },
     "dependencies": {
+        "@assemblyscript/loader": {
+            "version": "0.9.4",
+            "resolved": "https://registry.npmjs.org/@assemblyscript/loader/-/loader-0.9.4.tgz",
+            "integrity": "sha512-HazVq9zwTVwGmqdwYzu7WyQ6FQVZ7SwET0KKQuKm55jD0IfUpZgN0OPIiZG3zV1iSrVYcN0bdwLRXI/VNCYsUA=="
+        },
+        "@babel/code-frame": {
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+            "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+            "requires": {
+                "@babel/highlight": "^7.14.5"
+            }
+        },
+        "@babel/helper-validator-identifier": {
+            "version": "7.14.8",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.8.tgz",
+            "integrity": "sha512-ZGy6/XQjllhYQrNw/3zfWRwZCTVSiBLZ9DHVZxn9n2gip/7ab8mv2TWlKPIBk26RwedCBoWdjLmn+t9na2Gcow=="
+        },
+        "@babel/highlight": {
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+            "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+            "requires": {
+                "@babel/helper-validator-identifier": "^7.14.5",
+                "chalk": "^2.0.0",
+                "js-tokens": "^4.0.0"
+            }
+        },
+        "@ipld/car": {
+            "version": "3.1.9",
+            "resolved": "https://registry.npmjs.org/@ipld/car/-/car-3.1.9.tgz",
+            "integrity": "sha512-LNPisNrdqA79jSyb6Xg6L4/s+z37HqaGMAGgUEc2RKyraMQqI/NVy70CdIXDX1/rPojZa52zv66ETyLltztL0w==",
+            "requires": {
+                "@ipld/dag-cbor": "^6.0.0",
+                "@types/varint": "^6.0.0",
+                "multiformats": "^9.0.0",
+                "varint": "^6.0.0"
+            }
+        },
+        "@ipld/dag-cbor": {
+            "version": "6.0.6",
+            "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-6.0.6.tgz",
+            "integrity": "sha512-R53eO+oZ1lWtnVop5yi98+5HOCEjdK7OszSYDjkCy5ejes12n2Mk5YOdhkGaqgrxJ4Y1zJdNs9Gj5D0QDJuIbw==",
+            "requires": {
+                "cborg": "^1.2.1",
+                "multiformats": "^9.0.0"
+            }
+        },
+        "@ipld/dag-pb": {
+            "version": "2.1.5",
+            "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-2.1.5.tgz",
+            "integrity": "sha512-mdUiUZa+QFT0aPwjeU4mltrtCjl4ugxWgK5JluBV3F+mds7HANoWSuCvmK9f4qJYWEwN5xOHgZyFp3sQqSEmzw==",
+            "requires": {
+                "multiformats": "^9.0.0"
+            }
+        },
+        "@multiformats/base-x": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@multiformats/base-x/-/base-x-4.0.1.tgz",
+            "integrity": "sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw=="
+        },
+        "@protobufjs/aspromise": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+            "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
+        },
+        "@protobufjs/base64": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+            "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+        },
+        "@protobufjs/codegen": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+            "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+        },
+        "@protobufjs/eventemitter": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+            "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
+        },
+        "@protobufjs/fetch": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+            "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+            "requires": {
+                "@protobufjs/aspromise": "^1.1.1",
+                "@protobufjs/inquire": "^1.1.0"
+            }
+        },
+        "@protobufjs/float": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+            "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
+        },
+        "@protobufjs/inquire": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+            "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
+        },
+        "@protobufjs/path": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+            "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
+        },
+        "@protobufjs/pool": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+            "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
+        },
+        "@protobufjs/utf8": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+            "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
+        },
+        "@types/long": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
+            "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
+        },
+        "@types/minimatch": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
+            "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
+        },
+        "@types/minimist": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
+            "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
+        },
+        "@types/node": {
+            "version": "16.4.7",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.7.tgz",
+            "integrity": "sha512-aDDY54sst8sx47CWT6QQqIZp45yURq4dic0+HCYfYNcY5Ejlb/CLmFnRLfy3wQuYafOeh3lB/DAKaqRKBtcZmA=="
+        },
+        "@types/normalize-package-data": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
+            "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw=="
+        },
+        "@types/retry": {
+            "version": "0.12.1",
+            "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
+            "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g=="
+        },
+        "@types/varint": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/@types/varint/-/varint-6.0.0.tgz",
+            "integrity": "sha512-2jBazyxGl4644tvu3VAez8UA/AtrcEetT9HOeAbqZ/vAcRVL/ZDFQjSS7rkWusU5cyONQVUz+nwwrNZdMva4ow==",
+            "requires": {
+                "@types/node": "*"
+            }
+        },
+        "@web-std/blob": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/@web-std/blob/-/blob-2.1.2.tgz",
+            "integrity": "sha512-Twhh3jpfvi9zMKYm6MElqLLsgUoXN5aG/qGgqB6ng2kNzPIZATMwUxSMcJV3Fs3U5dTOjEVk4m8mK4RGCpclYg==",
+            "requires": {
+                "web-encoding": "1.1.5",
+                "web-streams-polyfill": "3.0.3"
+            }
+        },
+        "@web-std/fetch": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@web-std/fetch/-/fetch-2.0.3.tgz",
+            "integrity": "sha512-nr/fpYs3c4dzTEm0AMKhplAezxSh8tps3ulf3yYY0pbwHHt6jA1tL9rq2zMhbkMDSI+ZPQw7o6UW6VL5YVKZJA==",
+            "requires": {
+                "@web-std/blob": "^2.1.0",
+                "data-uri-to-buffer": "^3.0.1",
+                "web-streams-polyfill": "^3.0.2"
+            }
+        },
+        "@web-std/file": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@web-std/file/-/file-1.1.3.tgz",
+            "integrity": "sha512-u9xv+fEjUWPbR1c7St+Jai1qYEf2to0Iy3EZdsn9x/D2DuQrBc+zsnvgHHHsbR9GA95w3yDr0CiupshUDSjdZQ==",
+            "requires": {
+                "@web-std/blob": "^2.1.0"
+            }
+        },
+        "@zxing/text-encoding": {
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz",
+            "integrity": "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==",
+            "optional": true
+        },
+        "abort-controller": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+            "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+            "requires": {
+                "event-target-shim": "^5.0.0"
+            }
+        },
+        "ansi-styles": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "requires": {
+                "color-convert": "^1.9.0"
+            }
+        },
+        "any-signal": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-2.1.2.tgz",
+            "integrity": "sha512-B+rDnWasMi/eWcajPcCWSlYc7muXOrcYrqgyzcdKisl2H/WTlQ0gip1KyQfr0ZlxJdsuWCj/LWwQm7fhyhRfIQ==",
+            "requires": {
+                "abort-controller": "^3.0.0",
+                "native-abort-controller": "^1.0.3"
+            }
+        },
+        "arrify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+            "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+        },
+        "available-typed-arrays": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.4.tgz",
+            "integrity": "sha512-SA5mXJWrId1TaQjfxUYghbqQ/hYioKmLJvPJyDuYRtXXenFNMjj4hSSt1Cf1xsuXSXrtxrVC5Ot4eU6cOtBDdA=="
+        },
+        "balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+        },
+        "base64-js": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+        },
+        "bl": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-5.0.0.tgz",
+            "integrity": "sha512-8vxFNZ0pflFfi0WXA3WQXlj6CaMEwsmh63I1CNp0q+wWv8sD0ARx1KovSQd0l2GkwrMIOyedq0EF1FxI+RCZLQ==",
+            "requires": {
+                "buffer": "^6.0.3",
+                "inherits": "^2.0.4",
+                "readable-stream": "^3.4.0"
+            }
+        },
+        "blob-to-it": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/blob-to-it/-/blob-to-it-1.0.2.tgz",
+            "integrity": "sha512-yD8tikfTlUGEOSHExz4vDCIQFLaBPXIL0KcxGQt9RbwMVXBEh+jokdJyStvTXPgWrdKfwgk7RX8GPsgrYzsyng==",
+            "requires": {
+                "browser-readablestream-to-it": "^1.0.2"
+            }
+        },
+        "brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "browser-readablestream-to-it": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/browser-readablestream-to-it/-/browser-readablestream-to-it-1.0.2.tgz",
+            "integrity": "sha512-lv4M2Z6RKJpyJijJzBQL5MNssS7i8yedl+QkhnLCyPtgNGNSXv1KthzUnye9NlRAtBAI80X6S9i+vK09Rzjcvg=="
+        },
+        "buffer": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+            "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+            "requires": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.2.1"
+            }
+        },
+        "call-bind": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+            "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+            "requires": {
+                "function-bind": "^1.1.1",
+                "get-intrinsic": "^1.0.2"
+            }
+        },
+        "camelcase": {
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+            "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+        },
+        "camelcase-keys": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+            "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+            "requires": {
+                "camelcase": "^5.3.1",
+                "map-obj": "^4.0.0",
+                "quick-lru": "^4.0.1"
+            }
+        },
+        "carbites": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/carbites/-/carbites-1.0.6.tgz",
+            "integrity": "sha512-dS9IQvnrb5VIRvSTNz5Ff+mB9d2MFfi5mojtJi7Rlss79VeF190jr0sZdA7eW0CGHotvHkZaWuM6wgfD9PEFRg==",
+            "requires": {
+                "@ipld/car": "^3.0.1",
+                "@ipld/dag-cbor": "^6.0.3",
+                "@ipld/dag-pb": "^2.0.2",
+                "multiformats": "^9.0.4"
+            }
+        },
+        "cborg": {
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.3.6.tgz",
+            "integrity": "sha512-PsJqI9K9uieA4dqCfVb5gzWI0EO0axzr+LCWrETc0YmzqkLQswtVeDfhJcD7pTmkSjaVlwcQ3BybT7gcmIDMFw=="
+        },
+        "chalk": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+            "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+            }
+        },
+        "cids": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/cids/-/cids-1.1.7.tgz",
+            "integrity": "sha512-dlh+K0hMwFAFFjWQ2ZzxOhgGVNVREPdmk8cqHFui2U4sOodcemLMxdE5Ujga4cDcDQhWfldEPThkfu6KWBt1eA==",
+            "requires": {
+                "multibase": "^4.0.1",
+                "multicodec": "^3.0.1",
+                "multihashes": "^4.0.1",
+                "uint8arrays": "^2.1.3"
+            }
+        },
+        "color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "requires": {
+                "color-name": "1.1.3"
+            }
+        },
+        "color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+        },
+        "concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+        },
+        "data-uri-to-buffer": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
+            "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og=="
+        },
+        "debug": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+            "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+            "requires": {
+                "ms": "2.1.2"
+            }
+        },
+        "decamelize": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+        },
+        "decamelize-keys": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+            "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
+            "requires": {
+                "decamelize": "^1.1.0",
+                "map-obj": "^1.0.0"
+            },
+            "dependencies": {
+                "map-obj": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+                    "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
+                }
+            }
+        },
+        "define-properties": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+            "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+            "requires": {
+                "object-keys": "^1.0.12"
+            }
+        },
+        "dns-over-http-resolver": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-1.2.3.tgz",
+            "integrity": "sha512-miDiVSI6KSNbi4SVifzO/reD8rMnxgrlnkrlkugOLQpWQTe2qMdHsZp5DmfKjxNE+/T3VAAYLQUZMv9SMr6+AA==",
+            "requires": {
+                "debug": "^4.3.1",
+                "native-fetch": "^3.0.0",
+                "receptacle": "^1.3.2"
+            }
+        },
+        "electron-fetch": {
+            "version": "1.7.3",
+            "resolved": "https://registry.npmjs.org/electron-fetch/-/electron-fetch-1.7.3.tgz",
+            "integrity": "sha512-1AVMaxrHXTTMqd7EK0MGWusdqNr07Rpj8Th6bG4at0oNgIi/1LBwa9CjT/0Zy+M0k/tSJPS04nFxHj0SXDVgVw==",
+            "requires": {
+                "encoding": "^0.1.13"
+            }
+        },
+        "encoding": {
+            "version": "0.1.13",
+            "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+            "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+            "requires": {
+                "iconv-lite": "^0.6.2"
+            }
+        },
+        "err-code": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/err-code/-/err-code-3.0.1.tgz",
+            "integrity": "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA=="
+        },
+        "error-ex": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+            "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+            "requires": {
+                "is-arrayish": "^0.2.1"
+            }
+        },
+        "es-abstract": {
+            "version": "1.18.3",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.3.tgz",
+            "integrity": "sha512-nQIr12dxV7SSxE6r6f1l3DtAeEYdsGpps13dR0TwJg1S8gyp4ZPgy3FZcHBgbiQqnoqSTb+oC+kO4UQ0C/J8vw==",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "es-to-primitive": "^1.2.1",
+                "function-bind": "^1.1.1",
+                "get-intrinsic": "^1.1.1",
+                "has": "^1.0.3",
+                "has-symbols": "^1.0.2",
+                "is-callable": "^1.2.3",
+                "is-negative-zero": "^2.0.1",
+                "is-regex": "^1.1.3",
+                "is-string": "^1.0.6",
+                "object-inspect": "^1.10.3",
+                "object-keys": "^1.1.1",
+                "object.assign": "^4.1.2",
+                "string.prototype.trimend": "^1.0.4",
+                "string.prototype.trimstart": "^1.0.4",
+                "unbox-primitive": "^1.0.1"
+            }
+        },
+        "es-to-primitive": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+            "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+            "requires": {
+                "is-callable": "^1.1.4",
+                "is-date-object": "^1.0.1",
+                "is-symbol": "^1.0.2"
+            }
+        },
+        "escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+        },
+        "event-target-shim": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+            "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+        },
+        "events": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+            "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
+        },
+        "fast-fifo": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.0.0.tgz",
+            "integrity": "sha512-4VEXmjxLj7sbs8J//cn2qhRap50dGzF5n8fjay8mau+Jn4hxSeR3xPFwxMaQq/pDaq7+KQk0PAbC2+nWDkJrmQ=="
+        },
+        "files-from-path": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/files-from-path/-/files-from-path-0.2.0.tgz",
+            "integrity": "sha512-543OAjeBvPyInmEU4+4E6J/R1jR0yfR0MUsbOHGLruYv5PtnPxOGP0rj71a5DOE3aduKkRUpo5gFxcaeJLVcJw==",
+            "requires": {
+                "err-code": "^3.0.1",
+                "it-glob": "^0.0.13"
+            }
+        },
+        "find-up": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+            "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+            "requires": {
+                "locate-path": "^5.0.0",
+                "path-exists": "^4.0.0"
+            }
+        },
+        "foreach": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+            "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+        },
+        "function-bind": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+        },
+        "get-intrinsic": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+            "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+            "requires": {
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3",
+                "has-symbols": "^1.0.1"
+            }
+        },
+        "get-iterator": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/get-iterator/-/get-iterator-1.0.2.tgz",
+            "integrity": "sha512-v+dm9bNVfOYsY1OrhaCrmyOcYoSeVvbt+hHZ0Au+T+p1y+0Uyj9aMaGIeUTT6xdpRbWzDeYKvfOslPhggQMcsg=="
+        },
+        "hamt-sharding": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/hamt-sharding/-/hamt-sharding-2.0.0.tgz",
+            "integrity": "sha512-h8HKkMrqX6UC7I8hYRA1BT8pSC1TV1+V9HolGyWiNKRIztMQ980vWwjWZSLPFHtUKGMtOVBSVz5lIXuvlzwlWQ==",
+            "requires": {
+                "sparse-array": "^1.3.1",
+                "uint8arrays": "^2.1.2"
+            }
+        },
+        "hard-rejection": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
+            "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA=="
+        },
+        "has": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+            "requires": {
+                "function-bind": "^1.1.1"
+            }
+        },
+        "has-bigints": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
+            "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA=="
+        },
+        "has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+        },
+        "has-symbols": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+            "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+        },
+        "hosted-git-info": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.2.tgz",
+            "integrity": "sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==",
+            "requires": {
+                "lru-cache": "^6.0.0"
+            }
+        },
+        "iconv-lite": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "requires": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            }
+        },
+        "idb-keyval": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-5.1.0.tgz",
+            "integrity": "sha512-2hvhK8CZ3dG3S9Esfuq9Gxjtjdq7XLRiBVDPLe/+CzDe4X9g7Mr3peQn+/9Xz19M/Dtyjc2lEMNVxQFvV/0BtQ==",
+            "requires": {
+                "safari-14-idb-fix": "^1.0.4"
+            }
+        },
+        "ieee754": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+        },
+        "indent-string": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+            "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
+        },
+        "inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
+        "interface-blockstore": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/interface-blockstore/-/interface-blockstore-1.0.0.tgz",
+            "integrity": "sha512-wkBezBLWF7BuXAOljfdj0H2xWy7pW8Y5mQlv7HqI1wKcUmVVXNa9XGPAF8j/HQ1ZbjJdftISAD932Q4AFgG0zg==",
+            "requires": {
+                "err-code": "^3.0.1",
+                "interface-store": "^0.1.1",
+                "it-all": "^1.0.5",
+                "it-drain": "^1.0.4",
+                "it-filter": "^1.0.2",
+                "it-take": "^1.0.1",
+                "multiformats": "^9.0.4"
+            }
+        },
+        "interface-datastore": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-4.0.2.tgz",
+            "integrity": "sha512-/XRmD7oagZMTaK25rV3WFrejLoUwxZcpgE+eNyZNYvb2jlB5P3MwJCIbetJSlVYK7yvaFmJi8s3f9VLcxJjdog==",
+            "requires": {
+                "err-code": "^3.0.1",
+                "interface-store": "^0.0.2",
+                "ipfs-utils": "^8.1.2",
+                "iso-random-stream": "^2.0.0",
+                "it-all": "^1.0.2",
+                "it-drain": "^1.0.1",
+                "it-filter": "^1.0.2",
+                "it-take": "^1.0.1",
+                "nanoid": "^3.0.2",
+                "uint8arrays": "^2.1.5"
+            },
+            "dependencies": {
+                "interface-store": {
+                    "version": "0.0.2",
+                    "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-0.0.2.tgz",
+                    "integrity": "sha512-t4c9GKXH1Vi/WxmppGyIi6iedbGo92YmLneopHmbIEIp27ep7VnrYGA6lM/rLsFo5Tj6TJgIqr3FOk8mvPgIWQ=="
+                }
+            }
+        },
+        "interface-store": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-0.1.1.tgz",
+            "integrity": "sha512-ynnjIOybDZc0Brep3HHSa2RVlo/M5g7kuL/leui7o21EusKcLJS170vCJ8rliisc3c4jyd9ao5PthkGlBaX29g=="
+        },
+        "ip-regex": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
+            "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q=="
+        },
+        "ipfs-car": {
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/ipfs-car/-/ipfs-car-0.5.3.tgz",
+            "integrity": "sha512-jQVdKeiBCGyV5J5COpBabXgTkNxLCzii/oQOeB2qfLx679e9TZ0g1egb0fEcnrbHCkS4lh1/GqeP/UTMS5MINg==",
+            "requires": {
+                "@ipld/car": "^3.1.4",
+                "@web-std/blob": "^2.1.1",
+                "bl": "^5.0.0",
+                "idb-keyval": "^5.0.6",
+                "interface-blockstore": "^1.0.0",
+                "ipfs-core-types": "^0.5.2",
+                "ipfs-core-utils": "^0.8.0",
+                "ipfs-unixfs-exporter": "^6.0.0",
+                "ipfs-unixfs-importer": "^8.0.0",
+                "ipfs-utils": "^8.1.0",
+                "it-all": "^1.0.5",
+                "it-last": "^1.0.5",
+                "it-pipe": "^1.1.0",
+                "meow": "^9.0.0",
+                "move-file": "^2.1.0",
+                "multiformats": "^9.3.0",
+                "stream-to-it": "^0.2.3",
+                "streaming-iterables": "^6.0.0",
+                "uint8arrays": "^2.1.5"
+            }
+        },
+        "ipfs-core-types": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/ipfs-core-types/-/ipfs-core-types-0.5.2.tgz",
+            "integrity": "sha512-DOQeL+GFGYMTlnbdtMeBzvfVnyAalSgCfPr8XUCI+FVBZZWwzkt5jZZzGDmF87HVRrMR3FuVyBKZj772mcXKyQ==",
+            "requires": {
+                "cids": "^1.1.6",
+                "interface-datastore": "^4.0.0",
+                "ipld-block": "^0.11.1",
+                "multiaddr": "^9.0.1",
+                "multibase": "^4.0.2"
+            }
+        },
+        "ipfs-core-utils": {
+            "version": "0.8.3",
+            "resolved": "https://registry.npmjs.org/ipfs-core-utils/-/ipfs-core-utils-0.8.3.tgz",
+            "integrity": "sha512-PY7PkCgCtVYtNOe1C3ew1+5D9NqXqizb886R/lyGWe+KsmWtBQkQIk0ZIDwKyHGvG2KA2QQeIDzdOmzBQBJtHQ==",
+            "requires": {
+                "any-signal": "^2.1.2",
+                "blob-to-it": "^1.0.1",
+                "browser-readablestream-to-it": "^1.0.1",
+                "cids": "^1.1.6",
+                "err-code": "^3.0.1",
+                "ipfs-core-types": "^0.5.2",
+                "ipfs-unixfs": "^4.0.3",
+                "ipfs-utils": "^8.1.2",
+                "it-all": "^1.0.4",
+                "it-map": "^1.0.4",
+                "it-peekable": "^1.0.1",
+                "multiaddr": "^9.0.1",
+                "multiaddr-to-uri": "^7.0.0",
+                "parse-duration": "^1.0.0",
+                "timeout-abort-controller": "^1.1.1",
+                "uint8arrays": "^2.1.3"
+            }
+        },
+        "ipfs-unixfs": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-4.0.3.tgz",
+            "integrity": "sha512-hzJ3X4vlKT8FQ3Xc4M1szaFVjsc1ZydN+E4VQ91aXxfpjFn9G2wsMo1EFdAXNq/BUnN5dgqIOMP5zRYr3DTsAw==",
+            "requires": {
+                "err-code": "^3.0.1",
+                "protobufjs": "^6.10.2"
+            }
+        },
+        "ipfs-unixfs-exporter": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/ipfs-unixfs-exporter/-/ipfs-unixfs-exporter-6.0.1.tgz",
+            "integrity": "sha512-lVmCIByxJV5llUHBLC/iRFLP/s07iJl0hA5oofYP6SMUOeNiyZmY6ceMQnZHaFHRlkcg2giC0qnJvO2fNhdY5w==",
+            "requires": {
+                "@ipld/dag-cbor": "^6.0.4",
+                "@ipld/dag-pb": "^2.0.2",
+                "err-code": "^3.0.1",
+                "hamt-sharding": "^2.0.0",
+                "interface-blockstore": "^1.0.0",
+                "ipfs-unixfs": "^5.0.0",
+                "it-last": "^1.0.5",
+                "multiformats": "^9.4.2",
+                "murmurhash3js-revisited": "^3.0.0",
+                "uint8arrays": "^2.1.7"
+            },
+            "dependencies": {
+                "ipfs-unixfs": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-5.0.0.tgz",
+                    "integrity": "sha512-6FpBtsxB/9R7o7LGmSMaIoYkWO/cK+JYcj22QYIZaiA5dlk28Dvqme18bA43A7UKEc0M8I7mwD92ZXrlhJ/C7Q==",
+                    "requires": {
+                        "err-code": "^3.0.1",
+                        "protobufjs": "^6.10.2"
+                    }
+                }
+            }
+        },
+        "ipfs-unixfs-importer": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/ipfs-unixfs-importer/-/ipfs-unixfs-importer-8.0.1.tgz",
+            "integrity": "sha512-k7TW6R8vMyDffl5sZeZ9JYIJslvpYtjVdF0bX8fESAOr+/L3PsqA9ZfssDjPlRqJbZz6qKqMDcx1oWUCaJ4cgA==",
+            "requires": {
+                "@ipld/dag-pb": "^2.0.2",
+                "bl": "^5.0.0",
+                "err-code": "^3.0.1",
+                "hamt-sharding": "^2.0.0",
+                "interface-blockstore": "^1.0.0",
+                "ipfs-unixfs": "^5.0.0",
+                "it-all": "^1.0.5",
+                "it-batch": "^1.0.8",
+                "it-first": "^1.0.6",
+                "it-parallel-batch": "^1.0.9",
+                "merge-options": "^3.0.4",
+                "multiformats": "^9.4.2",
+                "murmurhash3js-revisited": "^3.0.0",
+                "rabin-wasm": "^0.1.4",
+                "uint8arrays": "^2.1.7"
+            },
+            "dependencies": {
+                "ipfs-unixfs": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-5.0.0.tgz",
+                    "integrity": "sha512-6FpBtsxB/9R7o7LGmSMaIoYkWO/cK+JYcj22QYIZaiA5dlk28Dvqme18bA43A7UKEc0M8I7mwD92ZXrlhJ/C7Q==",
+                    "requires": {
+                        "err-code": "^3.0.1",
+                        "protobufjs": "^6.10.2"
+                    }
+                }
+            }
+        },
+        "ipfs-utils": {
+            "version": "8.1.4",
+            "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-8.1.4.tgz",
+            "integrity": "sha512-QJjyRh4KzlkmtAOn/fOHYyjHGuG+Ows7xJGG8eiM/v325VvJhjJ1tWJobI6zrNDeFKjZcx1uNysE3MR2/dSiXQ==",
+            "requires": {
+                "abort-controller": "^3.0.0",
+                "any-signal": "^2.1.0",
+                "buffer": "^6.0.1",
+                "electron-fetch": "^1.7.2",
+                "err-code": "^3.0.1",
+                "is-electron": "^2.2.0",
+                "iso-url": "^1.1.5",
+                "it-glob": "~0.0.11",
+                "it-to-stream": "^1.0.0",
+                "merge-options": "^3.0.4",
+                "nanoid": "^3.1.20",
+                "native-abort-controller": "^1.0.3",
+                "native-fetch": "^3.0.0",
+                "node-fetch": "npm:@achingbrain/node-fetch@^2.6.4",
+                "react-native-fetch-api": "^2.0.0",
+                "stream-to-it": "^0.2.2"
+            }
+        },
+        "ipld-block": {
+            "version": "0.11.1",
+            "resolved": "https://registry.npmjs.org/ipld-block/-/ipld-block-0.11.1.tgz",
+            "integrity": "sha512-sDqqLqD5qh4QzGq6ssxLHUCnH4emCf/8F8IwjQM2cjEEIEHMUj57XhNYgmGbemdYPznUhffxFGEHsruh5+HQRw==",
+            "requires": {
+                "cids": "^1.0.0"
+            }
+        },
+        "is-arguments": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.0.tgz",
+            "integrity": "sha512-1Ij4lOMPl/xB5kBDn7I+b2ttPMKa8szhEIrXDuXQD/oe3HJLTLhqhgGspwgyGd6MOywBUqVvYicF72lkgDnIHg==",
+            "requires": {
+                "call-bind": "^1.0.0"
+            }
+        },
+        "is-arrayish": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+        },
+        "is-bigint": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.2.tgz",
+            "integrity": "sha512-0JV5+SOCQkIdzjBK9buARcV804Ddu7A0Qet6sHi3FimE9ne6m4BGQZfRn+NZiXbBk4F4XmHfDZIipLj9pX8dSA=="
+        },
+        "is-boolean-object": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.1.tgz",
+            "integrity": "sha512-bXdQWkECBUIAcCkeH1unwJLIpZYaa5VvuygSyS/c2lf719mTKZDU5UdDRlpd01UjADgmW8RfqaP+mRaVPdr/Ng==",
+            "requires": {
+                "call-bind": "^1.0.2"
+            }
+        },
+        "is-callable": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+            "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ=="
+        },
+        "is-core-module": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.5.0.tgz",
+            "integrity": "sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==",
+            "requires": {
+                "has": "^1.0.3"
+            }
+        },
+        "is-date-object": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.4.tgz",
+            "integrity": "sha512-/b4ZVsG7Z5XVtIxs/h9W8nvfLgSAyKYdtGWQLbqy6jA1icmgjf8WCoTKgeS4wy5tYaPePouzFMANbnj94c2Z+A=="
+        },
+        "is-electron": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.0.tgz",
+            "integrity": "sha512-SpMppC2XR3YdxSzczXReBjqs2zGscWQpBIKqwXYBFic0ERaxNVgwLCHwOLZeESfdJQjX0RDvrJ1lBXX2ij+G1Q=="
+        },
+        "is-generator-function": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.9.tgz",
+            "integrity": "sha512-ZJ34p1uvIfptHCN7sFTjGibB9/oBg17sHqzDLfuwhvmN/qLVvIQXRQ8licZQ35WJ8KuEQt/etnnzQFI9C9Ue/A=="
+        },
+        "is-ip": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
+            "integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
+            "requires": {
+                "ip-regex": "^4.0.0"
+            }
+        },
+        "is-negative-zero": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
+            "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w=="
+        },
+        "is-number-object": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.5.tgz",
+            "integrity": "sha512-RU0lI/n95pMoUKu9v1BZP5MBcZuNSVJkMkAG2dJqC4z2GlkGUNeH68SuHuBKBD/XFe+LHZ+f9BKkLET60Niedw=="
+        },
+        "is-plain-obj": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+            "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
+        },
+        "is-regex": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
+            "integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "has-symbols": "^1.0.2"
+            }
+        },
+        "is-string": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.6.tgz",
+            "integrity": "sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w=="
+        },
+        "is-symbol": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+            "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+            "requires": {
+                "has-symbols": "^1.0.2"
+            }
+        },
+        "is-typed-array": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.5.tgz",
+            "integrity": "sha512-S+GRDgJlR3PyEbsX/Fobd9cqpZBuvUS+8asRqYDMLCb2qMzt1oz5m5oxQCxOgUDxiWsOVNi4yaF+/uvdlHlYug==",
+            "requires": {
+                "available-typed-arrays": "^1.0.2",
+                "call-bind": "^1.0.2",
+                "es-abstract": "^1.18.0-next.2",
+                "foreach": "^2.0.5",
+                "has-symbols": "^1.0.1"
+            }
+        },
+        "iso-random-stream": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/iso-random-stream/-/iso-random-stream-2.0.0.tgz",
+            "integrity": "sha512-lGuIu104KfBV9ubYTSaE3GeAr6I69iggXxBHbTBc5u/XKlwlWl0LCytnkIZissaKqvxablwRD9B3ktVnmIUnEg==",
+            "requires": {
+                "events": "^3.3.0",
+                "readable-stream": "^3.4.0"
+            }
+        },
+        "iso-url": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-1.1.5.tgz",
+            "integrity": "sha512-+3JqoKdBTGmyv9vOkS6b9iHhvK34UajfTibrH/1HOK8TI7K2VsM0qOCd+aJdWKtSOA8g3PqZfcwDmnR0p3klqQ=="
+        },
+        "it-all": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/it-all/-/it-all-1.0.5.tgz",
+            "integrity": "sha512-ygD4kA4vp8fi+Y+NBgEKt6W06xSbv6Ub/0V8d1r3uCyJ9Izwa1UspkIOlqY9fOee0Z1w3WRo1+VWyAU4DgtufA=="
+        },
+        "it-batch": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/it-batch/-/it-batch-1.0.8.tgz",
+            "integrity": "sha512-RfEa1rxOPnicXvaXJ1qNThxPrq8/Lc+KwSVWHFEEOp2CrjpjhR5WfmBJozhkbzZ/r/Gl0HjzVVrt0NpG8qczDQ=="
+        },
+        "it-drain": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/it-drain/-/it-drain-1.0.4.tgz",
+            "integrity": "sha512-coB7mcyZ4lWBQKoQGJuqM+P94pvpn2T3KY27vcVWPqeB1WmoysRC76VZnzAqrBWzpWcoEJMjZ+fsMBslxNaWfQ=="
+        },
+        "it-filter": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/it-filter/-/it-filter-1.0.2.tgz",
+            "integrity": "sha512-rxFUyPCrhk7WrNxD8msU10iEPhQmROoqwuyWmQUYY1PtopwUGBYyra9EYG2nRZADYeuT83cohKWmKCWPzpeyiw=="
+        },
+        "it-first": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/it-first/-/it-first-1.0.6.tgz",
+            "integrity": "sha512-wiI02c+G1BVuu0jz30Nsr1/et0cpSRulKUusN8HDZXxuX4MdUzfMp2P4JUk+a49Wr1kHitRLrnnh3+UzJ6neaQ=="
+        },
+        "it-glob": {
+            "version": "0.0.13",
+            "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-0.0.13.tgz",
+            "integrity": "sha512-0Hcd5BraJUPzL28NWiFbdNrcdyNxNTKKdU3sjdFiYynNTQpwlG2UKW31X7bp+XhJwux/oPzIquo5ioztVmc2RQ==",
+            "requires": {
+                "@types/minimatch": "^3.0.4",
+                "minimatch": "^3.0.4"
+            }
+        },
+        "it-last": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/it-last/-/it-last-1.0.5.tgz",
+            "integrity": "sha512-PV/2S4zg5g6dkVuKfgrQfN2rUN4wdTI1FzyAvU+i8RV96syut40pa2s9Dut5X7SkjwA3P0tOhLABLdnOJ0Y/4Q=="
+        },
+        "it-map": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/it-map/-/it-map-1.0.5.tgz",
+            "integrity": "sha512-EElupuWhHVStUgUY+OfTJIS2MZed96lDrAXzJUuqiiqLnIKoBRqtX1ZG2oR0bGDsSppmz83MtzCeKLZ9TVAUxQ=="
+        },
+        "it-parallel-batch": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/it-parallel-batch/-/it-parallel-batch-1.0.9.tgz",
+            "integrity": "sha512-lfCxXsHoEtgyWj5HLrEQXlZF0p3c0hfYeVJAbxQIHIzHLq4lkYplUIe3UGxYl4n1Sjpcs6YL/87352399aVeIA==",
+            "requires": {
+                "it-batch": "^1.0.8"
+            }
+        },
+        "it-peekable": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-1.0.2.tgz",
+            "integrity": "sha512-LRPLu94RLm+lxLZbChuc9iCXrKCOu1obWqxfaKhF00yIp30VGkl741b5P60U+rdBxuZD/Gt1bnmakernv7bVFg=="
+        },
+        "it-pipe": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-1.1.0.tgz",
+            "integrity": "sha512-lF0/3qTVeth13TOnHVs0BTFaziwQF7m5Gg+E6JV0BXcLKutC92YjSi7bASgkPOXaLEb+YvNZrPorGMBIJvZfxg=="
+        },
+        "it-take": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/it-take/-/it-take-1.0.1.tgz",
+            "integrity": "sha512-6H6JAWYcyumKSpcIPLs6tHN4xnibphmyU79WQaYVCBtaBOzf4fn75wzvSH8fH8fcMlPBTWY1RlmOWleQxBt2Ug=="
+        },
+        "it-to-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/it-to-stream/-/it-to-stream-1.0.0.tgz",
+            "integrity": "sha512-pLULMZMAB/+vbdvbZtebC0nWBTbG581lk6w8P7DfIIIKUfa8FbY7Oi0FxZcFPbxvISs7A9E+cMpLDBc1XhpAOA==",
+            "requires": {
+                "buffer": "^6.0.3",
+                "fast-fifo": "^1.0.0",
+                "get-iterator": "^1.0.2",
+                "p-defer": "^3.0.0",
+                "p-fifo": "^1.0.0",
+                "readable-stream": "^3.6.0"
+            }
+        },
+        "js-tokens": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+        },
+        "json-parse-even-better-errors": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+            "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
+        },
+        "kind-of": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+            "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
+        },
+        "lines-and-columns": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+            "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
+        },
+        "locate-path": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+            "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+            "requires": {
+                "p-locate": "^4.1.0"
+            }
+        },
+        "long": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+            "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+        },
+        "lru-cache": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "requires": {
+                "yallist": "^4.0.0"
+            }
+        },
+        "map-obj": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.2.1.tgz",
+            "integrity": "sha512-+WA2/1sPmDj1dlvvJmB5G6JKfY9dpn7EVBUL06+y6PoljPkh+6V1QihwxNkbcGxCRjt2b0F9K0taiCuo7MbdFQ=="
+        },
+        "meow": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/meow/-/meow-9.0.0.tgz",
+            "integrity": "sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==",
+            "requires": {
+                "@types/minimist": "^1.2.0",
+                "camelcase-keys": "^6.2.2",
+                "decamelize": "^1.2.0",
+                "decamelize-keys": "^1.1.0",
+                "hard-rejection": "^2.1.0",
+                "minimist-options": "4.1.0",
+                "normalize-package-data": "^3.0.0",
+                "read-pkg-up": "^7.0.1",
+                "redent": "^3.0.0",
+                "trim-newlines": "^3.0.0",
+                "type-fest": "^0.18.0",
+                "yargs-parser": "^20.2.3"
+            }
+        },
+        "merge-options": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+            "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+            "requires": {
+                "is-plain-obj": "^2.1.0"
+            }
+        },
+        "min-indent": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+            "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="
+        },
+        "minimatch": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "requires": {
+                "brace-expansion": "^1.1.7"
+            }
+        },
         "minimist": {
             "version": "1.2.5",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
             "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         },
+        "minimist-options": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
+            "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
+            "requires": {
+                "arrify": "^1.0.1",
+                "is-plain-obj": "^1.1.0",
+                "kind-of": "^6.0.3"
+            },
+            "dependencies": {
+                "is-plain-obj": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+                    "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+                }
+            }
+        },
+        "move-file": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/move-file/-/move-file-2.1.0.tgz",
+            "integrity": "sha512-i9qLW6gqboJ5Ht8bauZi7KlTnQ3QFpBCvMvFfEcHADKgHGeJ9BZMO7SFCTwHPV9Qa0du9DYY1Yx3oqlGt30nXA==",
+            "requires": {
+                "path-exists": "^4.0.0"
+            }
+        },
+        "ms": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "multiaddr": {
+            "version": "9.0.2",
+            "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-9.0.2.tgz",
+            "integrity": "sha512-YFaEb9t4yXSbaGksSEdg+Kn2U02s7w4wXUgyEMQmPxFJj7CfVHY10WOsScAX/rK6Soa15S1zXYadqH9TtlVreQ==",
+            "requires": {
+                "cids": "^1.0.0",
+                "dns-over-http-resolver": "^1.0.0",
+                "err-code": "^3.0.1",
+                "is-ip": "^3.1.0",
+                "multibase": "^4.0.2",
+                "uint8arrays": "^2.1.3",
+                "varint": "^6.0.0"
+            }
+        },
+        "multiaddr-to-uri": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/multiaddr-to-uri/-/multiaddr-to-uri-7.0.0.tgz",
+            "integrity": "sha512-VbscDpLcbV0m25tJqfnZSfbjVUuNlPa4BbD5l/7me1t0lc3SWI0XAoO5E/PNJF0e1qUlbdq7yjVFEQjUT+9r0g==",
+            "requires": {
+                "multiaddr": "^9.0.1"
+            }
+        },
+        "multibase": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/multibase/-/multibase-4.0.4.tgz",
+            "integrity": "sha512-8/JmrdSGzlw6KTgAJCOqUBSGd1V6186i/X8dDCGy/lbCKrQ+1QB6f3HE+wPr7Tpdj4U3gutaj9jG2rNX6UpiJg==",
+            "requires": {
+                "@multiformats/base-x": "^4.0.1"
+            }
+        },
+        "multicodec": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-3.1.0.tgz",
+            "integrity": "sha512-f6d4DhbQ9a8WiJ/wpbKgeJSeR0/juP/1wnjbKdZ0KAWDkC/z7Lb3xOegMUG+uTcfwSYf6j1eTvFf8HDgqPRGmQ==",
+            "requires": {
+                "uint8arrays": "^2.1.5",
+                "varint": "^6.0.0"
+            }
+        },
+        "multiformats": {
+            "version": "9.4.3",
+            "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.4.3.tgz",
+            "integrity": "sha512-sCNjBP/NPCeQu83Mst8IQZq9+HuR7Catvk/m7CeH0r/nupsU6gM7GINf5E1HCDRxDeU+Cgda/WPmcwQhYs3dyA=="
+        },
+        "multihashes": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-4.0.2.tgz",
+            "integrity": "sha512-xpx++1iZr4ZQHjN1mcrXS6904R36LWLxX/CBifczjtmrtCXEX623DMWOF1eiNSg+pFpiZDFVBgou/4v6ayCHSQ==",
+            "requires": {
+                "multibase": "^4.0.1",
+                "uint8arrays": "^2.1.3",
+                "varint": "^5.0.2"
+            },
+            "dependencies": {
+                "varint": {
+                    "version": "5.0.2",
+                    "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
+                    "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
+                }
+            }
+        },
+        "murmurhash3js-revisited": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/murmurhash3js-revisited/-/murmurhash3js-revisited-3.0.0.tgz",
+            "integrity": "sha512-/sF3ee6zvScXMb1XFJ8gDsSnY+X8PbOyjIuBhtgis10W2Jx4ZjIhikUCIF9c4gpJxVnQIsPAFrSwTCuAjicP6g=="
+        },
+        "nanoid": {
+            "version": "3.1.23",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
+            "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw=="
+        },
+        "native-abort-controller": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/native-abort-controller/-/native-abort-controller-1.0.3.tgz",
+            "integrity": "sha512-fd5LY5q06mHKZPD5FmMrn7Lkd2H018oBGKNOAdLpctBDEPFKsfJ1nX9ke+XRa8PEJJpjqrpQkGjq2IZ27QNmYA==",
+            "requires": {}
+        },
+        "native-fetch": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-3.0.0.tgz",
+            "integrity": "sha512-G3Z7vx0IFb/FQ4JxvtqGABsOTIqRWvgQz6e+erkB+JJD6LrszQtMozEHI4EkmgZQvnGHrpLVzUWk7t4sJCIkVw==",
+            "requires": {}
+        },
+        "node-fetch": {
+            "version": "npm:@achingbrain/node-fetch@2.6.7",
+            "resolved": "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz",
+            "integrity": "sha512-iTASGs+HTFK5E4ZqcMsHmeJ4zodyq8L38lZV33jwqcBJYoUt3HjN4+ot+O9/0b+ke8ddE7UgOtVuZN/OkV19/g=="
+        },
+        "normalize-package-data": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.2.tgz",
+            "integrity": "sha512-6CdZocmfGaKnIHPVFhJJZ3GuR8SsLKvDANFp47Jmy51aKIr8akjAWTSxtpI+MBgBFdSMRyo4hMpDlT6dTffgZg==",
+            "requires": {
+                "hosted-git-info": "^4.0.1",
+                "resolve": "^1.20.0",
+                "semver": "^7.3.4",
+                "validate-npm-package-license": "^3.0.1"
+            }
+        },
+        "object-inspect": {
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
+            "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg=="
+        },
+        "object-keys": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+        },
+        "object.assign": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+            "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+            "requires": {
+                "call-bind": "^1.0.0",
+                "define-properties": "^1.1.3",
+                "has-symbols": "^1.0.1",
+                "object-keys": "^1.1.1"
+            }
+        },
+        "p-defer": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
+            "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
+        },
+        "p-fifo": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-fifo/-/p-fifo-1.0.0.tgz",
+            "integrity": "sha512-IjoCxXW48tqdtDFz6fqo5q1UfFVjjVZe8TC1QRflvNUJtNfCUhxOUw6MOVZhDPjqhSzc26xKdugsO17gmzd5+A==",
+            "requires": {
+                "fast-fifo": "^1.0.0",
+                "p-defer": "^3.0.0"
+            }
+        },
+        "p-limit": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+            "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+            "requires": {
+                "p-try": "^2.0.0"
+            }
+        },
+        "p-locate": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+            "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+            "requires": {
+                "p-limit": "^2.2.0"
+            }
+        },
+        "p-retry": {
+            "version": "4.6.1",
+            "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.1.tgz",
+            "integrity": "sha512-e2xXGNhZOZ0lfgR9kL34iGlU8N/KO0xZnQxVEwdeOvpqNDQfdnxIYizvWtK8RglUa3bGqI8g0R/BdfzLMxRkiA==",
+            "requires": {
+                "@types/retry": "^0.12.0",
+                "retry": "^0.13.1"
+            }
+        },
+        "p-try": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+        },
+        "parse-duration": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/parse-duration/-/parse-duration-1.0.0.tgz",
+            "integrity": "sha512-X4kUkCTHU1N/kEbwK9FpUJ0UZQa90VzeczfS704frR30gljxDG0pSziws06XlK+CGRSo/1wtG1mFIdBFQTMQNw=="
+        },
+        "parse-json": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+            "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+            "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "error-ex": "^1.3.1",
+                "json-parse-even-better-errors": "^2.3.0",
+                "lines-and-columns": "^1.1.6"
+            }
+        },
+        "parse-link-header": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-1.0.1.tgz",
+            "integrity": "sha1-vt/g0hGK64S+deewJUGeyKYRQKc=",
+            "requires": {
+                "xtend": "~4.0.1"
+            }
+        },
+        "path-exists": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+            "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+        },
+        "path-parse": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+        },
+        "protobufjs": {
+            "version": "6.11.2",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.2.tgz",
+            "integrity": "sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==",
+            "requires": {
+                "@protobufjs/aspromise": "^1.1.2",
+                "@protobufjs/base64": "^1.1.2",
+                "@protobufjs/codegen": "^2.0.4",
+                "@protobufjs/eventemitter": "^1.1.0",
+                "@protobufjs/fetch": "^1.1.0",
+                "@protobufjs/float": "^1.0.2",
+                "@protobufjs/inquire": "^1.1.0",
+                "@protobufjs/path": "^1.1.2",
+                "@protobufjs/pool": "^1.1.0",
+                "@protobufjs/utf8": "^1.1.0",
+                "@types/long": "^4.0.1",
+                "@types/node": ">=13.7.0",
+                "long": "^4.0.0"
+            }
+        },
+        "quick-lru": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+            "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g=="
+        },
+        "rabin-wasm": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/rabin-wasm/-/rabin-wasm-0.1.5.tgz",
+            "integrity": "sha512-uWgQTo7pim1Rnj5TuWcCewRDTf0PEFTSlaUjWP4eY9EbLV9em08v89oCz/WO+wRxpYuO36XEHp4wgYQnAgOHzA==",
+            "requires": {
+                "@assemblyscript/loader": "^0.9.4",
+                "bl": "^5.0.0",
+                "debug": "^4.3.1",
+                "minimist": "^1.2.5",
+                "node-fetch": "^2.6.1",
+                "readable-stream": "^3.6.0"
+            }
+        },
+        "react-native-fetch-api": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/react-native-fetch-api/-/react-native-fetch-api-2.0.0.tgz",
+            "integrity": "sha512-GOA8tc1EVYLnHvma/TU9VTgLOyralO7eATRuCDchQveXW9Fr9vXygyq9iwqmM7YRZ8qRJfEt9xOS7OYMdJvRFw==",
+            "requires": {
+                "p-defer": "^3.0.0"
+            }
+        },
+        "read-pkg": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+            "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+            "requires": {
+                "@types/normalize-package-data": "^2.4.0",
+                "normalize-package-data": "^2.5.0",
+                "parse-json": "^5.0.0",
+                "type-fest": "^0.6.0"
+            },
+            "dependencies": {
+                "hosted-git-info": {
+                    "version": "2.8.9",
+                    "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+                    "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
+                },
+                "normalize-package-data": {
+                    "version": "2.5.0",
+                    "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+                    "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+                    "requires": {
+                        "hosted-git-info": "^2.1.4",
+                        "resolve": "^1.10.0",
+                        "semver": "2 || 3 || 4 || 5",
+                        "validate-npm-package-license": "^3.0.1"
+                    }
+                },
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+                },
+                "type-fest": {
+                    "version": "0.6.0",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+                    "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg=="
+                }
+            }
+        },
+        "read-pkg-up": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+            "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+            "requires": {
+                "find-up": "^4.1.0",
+                "read-pkg": "^5.2.0",
+                "type-fest": "^0.8.1"
+            },
+            "dependencies": {
+                "type-fest": {
+                    "version": "0.8.1",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+                    "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
+                }
+            }
+        },
+        "readable-stream": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+            "requires": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            }
+        },
+        "receptacle": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/receptacle/-/receptacle-1.3.2.tgz",
+            "integrity": "sha512-HrsFvqZZheusncQRiEE7GatOAETrARKV/lnfYicIm8lbvp/JQOdADOfhjBd2DajvoszEyxSM6RlAAIZgEoeu/A==",
+            "requires": {
+                "ms": "^2.1.1"
+            }
+        },
+        "redent": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+            "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+            "requires": {
+                "indent-string": "^4.0.0",
+                "strip-indent": "^3.0.0"
+            }
+        },
+        "resolve": {
+            "version": "1.20.0",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+            "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+            "requires": {
+                "is-core-module": "^2.2.0",
+                "path-parse": "^1.0.6"
+            }
+        },
+        "retimer": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/retimer/-/retimer-2.0.0.tgz",
+            "integrity": "sha512-KLXY85WkEq2V2bKex/LOO1ViXVn2KGYe4PYysAdYdjmraYIUsVkXu8O4am+8+5UbaaGl1qho4aqAAPHNQ4GSbg=="
+        },
+        "retry": {
+            "version": "0.13.1",
+            "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+            "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="
+        },
+        "safari-14-idb-fix": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/safari-14-idb-fix/-/safari-14-idb-fix-1.0.4.tgz",
+            "integrity": "sha512-4+Y2baQdgJpzu84d0QjySl70Kyygzf0pepVg8NVg4NnQEPpfC91fAn0baNvtStlCjUUxxiu0BOMiafa98fRRuA=="
+        },
+        "safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        },
+        "safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+        },
+        "semver": {
+            "version": "7.3.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+            "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+            "requires": {
+                "lru-cache": "^6.0.0"
+            }
+        },
+        "sparse-array": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/sparse-array/-/sparse-array-1.3.2.tgz",
+            "integrity": "sha512-ZT711fePGn3+kQyLuv1fpd3rNSkNF8vd5Kv2D+qnOANeyKs3fx6bUMGWRPvgTTcYV64QMqZKZwcuaQSP3AZ0tg=="
+        },
+        "spdx-correct": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+            "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
+            "requires": {
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "spdx-exceptions": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+            "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A=="
+        },
+        "spdx-expression-parse": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+            "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+            "requires": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "spdx-license-ids": {
+            "version": "3.0.9",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.9.tgz",
+            "integrity": "sha512-Ki212dKK4ogX+xDo4CtOZBVIwhsKBEfsEEcwmJfLQzirgc2jIWdzg40Unxz/HzEUqM1WFzVlQSMF9kZZ2HboLQ=="
+        },
+        "stream-to-it": {
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/stream-to-it/-/stream-to-it-0.2.4.tgz",
+            "integrity": "sha512-4vEbkSs83OahpmBybNJXlJd7d6/RxzkkSdT3I0mnGt79Xd2Kk+e1JqbvAvsQfCeKj3aKb0QIWkyK3/n0j506vQ==",
+            "requires": {
+                "get-iterator": "^1.0.2"
+            }
+        },
+        "streaming-iterables": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/streaming-iterables/-/streaming-iterables-6.0.0.tgz",
+            "integrity": "sha512-GYbJh0ife8PvryWSyFifY1m1uj6zO12d9duuP6xltiOolUz44eKasp5gbFhRbFbLy50ik6hcKn4Pbxl9AkxB+Q=="
+        },
+        "string_decoder": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+            "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+            "requires": {
+                "safe-buffer": "~5.2.0"
+            }
+        },
+        "string.prototype.trimend": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+            "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3"
+            }
+        },
+        "string.prototype.trimstart": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+            "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3"
+            }
+        },
+        "strip-indent": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+            "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+            "requires": {
+                "min-indent": "^1.0.0"
+            }
+        },
+        "supports-color": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "requires": {
+                "has-flag": "^3.0.0"
+            }
+        },
+        "timeout-abort-controller": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/timeout-abort-controller/-/timeout-abort-controller-1.1.1.tgz",
+            "integrity": "sha512-BsF9i3NAJag6T0ZEjki9j654zoafI2X6ayuNd6Tp8+Ul6Tr5s4jo973qFeiWrRSweqvskC+AHDKUmIW4b7pdhQ==",
+            "requires": {
+                "abort-controller": "^3.0.0",
+                "retimer": "^2.0.0"
+            }
+        },
+        "trim-newlines": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
+            "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw=="
+        },
+        "type-fest": {
+            "version": "0.18.1",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
+            "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw=="
+        },
+        "uint8arrays": {
+            "version": "2.1.8",
+            "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-2.1.8.tgz",
+            "integrity": "sha512-qpZ/B88mSea11W3LvoimtnGWIC2i3gGuXby5wBkn8jY+OFulbaQwyjpOYSyrASqgcNEvKdAkLiOwiUt5cPSdcQ==",
+            "requires": {
+                "multiformats": "^9.4.2"
+            }
+        },
+        "unbox-primitive": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
+            "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+            "requires": {
+                "function-bind": "^1.1.1",
+                "has-bigints": "^1.0.1",
+                "has-symbols": "^1.0.2",
+                "which-boxed-primitive": "^1.0.2"
+            }
+        },
+        "util": {
+            "version": "0.12.4",
+            "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
+            "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
+            "requires": {
+                "inherits": "^2.0.3",
+                "is-arguments": "^1.0.4",
+                "is-generator-function": "^1.0.7",
+                "is-typed-array": "^1.1.3",
+                "safe-buffer": "^5.1.2",
+                "which-typed-array": "^1.1.2"
+            }
+        },
+        "util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+        },
+        "validate-npm-package-license": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+            "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+            "requires": {
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
+            }
+        },
+        "varint": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
+            "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
+        },
+        "web-encoding": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.1.5.tgz",
+            "integrity": "sha512-HYLeVCdJ0+lBYV2FvNZmv3HJ2Nt0QYXqZojk3d9FJOLkwnuhzM9tmamh8d7HPM8QqjKH8DeHkFTx+CFlWpZZDA==",
+            "requires": {
+                "@zxing/text-encoding": "0.9.0",
+                "util": "^0.12.3"
+            }
+        },
+        "web-streams-polyfill": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.0.3.tgz",
+            "integrity": "sha512-d2H/t0eqRNM4w2WvmTdoeIvzAUSpK7JmATB8Nr2lb7nQ9BTIJVjbQ/TRFVEh2gUH1HwclPdoPtfMoFfetXaZnA=="
+        },
         "web3.storage": {
-            "version": "file:../../../web3.storage/packages/client",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/web3.storage/-/web3.storage-3.1.0.tgz",
+            "integrity": "sha512-CdxoQ4WKvXQMx2Hw7MOdCUOmwSpCdtOX+XI86EbiFwldXA3KmFdwF1b/VeYpQpKHEnheoANrO/owRujj3M22FQ==",
             "requires": {
                 "@ipld/car": "^3.1.4",
                 "@web-std/blob": "^2.1.0",
@@ -19,1711 +3939,52 @@
                 "browser-readablestream-to-it": "^1.0.2",
                 "carbites": "^1.0.6",
                 "files-from-path": "^0.2.0",
-                "ipfs-car": "^0.5.1",
+                "ipfs-car": "^0.5.3",
                 "p-retry": "^4.5.0",
+                "parse-link-header": "^1.0.1",
                 "streaming-iterables": "^6.0.0"
-            },
-            "dependencies": {
-                "@assemblyscript/loader": {
-                    "version": "0.9.4",
-                    "resolved": "https://registry.npmjs.org/@assemblyscript/loader/-/loader-0.9.4.tgz",
-                    "integrity": "sha512-HazVq9zwTVwGmqdwYzu7WyQ6FQVZ7SwET0KKQuKm55jD0IfUpZgN0OPIiZG3zV1iSrVYcN0bdwLRXI/VNCYsUA=="
-                },
-                "@babel/code-frame": {
-                    "version": "7.14.5",
-                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
-                    "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
-                    "requires": {
-                        "@babel/highlight": "^7.14.5"
-                    }
-                },
-                "@babel/helper-validator-identifier": {
-                    "version": "7.14.8",
-                    "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.8.tgz",
-                    "integrity": "sha512-ZGy6/XQjllhYQrNw/3zfWRwZCTVSiBLZ9DHVZxn9n2gip/7ab8mv2TWlKPIBk26RwedCBoWdjLmn+t9na2Gcow=="
-                },
-                "@babel/highlight": {
-                    "version": "7.14.5",
-                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-                    "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
-                    "requires": {
-                        "@babel/helper-validator-identifier": "^7.14.5",
-                        "chalk": "^2.0.0",
-                        "js-tokens": "^4.0.0"
-                    }
-                },
-                "@ipld/car": {
-                    "version": "3.1.7",
-                    "resolved": "https://registry.npmjs.org/@ipld/car/-/car-3.1.7.tgz",
-                    "integrity": "sha512-+rCR5rxPBpU9V9aVmCUujrli3V0t9qb4pLozhrHeUjJJS1PaF/D5zgIfTpzRsuQWp2O0ZriYzuwyppuPCqhAWw==",
-                    "requires": {
-                        "@ipld/dag-cbor": "^6.0.0",
-                        "@types/varint": "^6.0.0",
-                        "multiformats": "^9.0.0",
-                        "varint": "^6.0.0"
-                    }
-                },
-                "@ipld/dag-cbor": {
-                    "version": "6.0.6",
-                    "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-6.0.6.tgz",
-                    "integrity": "sha512-R53eO+oZ1lWtnVop5yi98+5HOCEjdK7OszSYDjkCy5ejes12n2Mk5YOdhkGaqgrxJ4Y1zJdNs9Gj5D0QDJuIbw==",
-                    "requires": {
-                        "cborg": "^1.2.1",
-                        "multiformats": "^9.0.0"
-                    }
-                },
-                "@ipld/dag-pb": {
-                    "version": "2.1.4",
-                    "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-2.1.4.tgz",
-                    "integrity": "sha512-aRGX6NVUuv18/lrD1vPpthIbwUMb4TAuwLG15IZrvWNVrZasRLJhnU18jT+eans6OZe5fWzo0wb0UgORFx8iXg==",
-                    "requires": {
-                        "multiformats": "^9.0.0"
-                    }
-                },
-                "@multiformats/base-x": {
-                    "version": "4.0.1",
-                    "resolved": "https://registry.npmjs.org/@multiformats/base-x/-/base-x-4.0.1.tgz",
-                    "integrity": "sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw=="
-                },
-                "@protobufjs/aspromise": {
-                    "version": "1.1.2",
-                    "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-                    "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
-                },
-                "@protobufjs/base64": {
-                    "version": "1.1.2",
-                    "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-                    "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
-                },
-                "@protobufjs/codegen": {
-                    "version": "2.0.4",
-                    "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-                    "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
-                },
-                "@protobufjs/eventemitter": {
-                    "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-                    "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
-                },
-                "@protobufjs/fetch": {
-                    "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-                    "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
-                    "requires": {
-                        "@protobufjs/aspromise": "^1.1.1",
-                        "@protobufjs/inquire": "^1.1.0"
-                    }
-                },
-                "@protobufjs/float": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-                    "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
-                },
-                "@protobufjs/inquire": {
-                    "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-                    "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
-                },
-                "@protobufjs/path": {
-                    "version": "1.1.2",
-                    "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-                    "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
-                },
-                "@protobufjs/pool": {
-                    "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-                    "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
-                },
-                "@protobufjs/utf8": {
-                    "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-                    "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
-                },
-                "@types/long": {
-                    "version": "4.0.1",
-                    "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
-                    "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
-                },
-                "@types/minimatch": {
-                    "version": "3.0.5",
-                    "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
-                    "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
-                },
-                "@types/minimist": {
-                    "version": "1.2.2",
-                    "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
-                    "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
-                },
-                "@types/node": {
-                    "version": "16.4.0",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.0.tgz",
-                    "integrity": "sha512-HrJuE7Mlqcjj+00JqMWpZ3tY8w7EUd+S0U3L1+PQSWiXZbOgyQDvi+ogoUxaHApPJq5diKxYBQwA3iIlNcPqOg=="
-                },
-                "@types/normalize-package-data": {
-                    "version": "2.4.1",
-                    "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
-                    "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw=="
-                },
-                "@types/retry": {
-                    "version": "0.12.1",
-                    "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
-                    "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g=="
-                },
-                "@types/varint": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/@types/varint/-/varint-6.0.0.tgz",
-                    "integrity": "sha512-2jBazyxGl4644tvu3VAez8UA/AtrcEetT9HOeAbqZ/vAcRVL/ZDFQjSS7rkWusU5cyONQVUz+nwwrNZdMva4ow==",
-                    "requires": {
-                        "@types/node": "*"
-                    }
-                },
-                "@web-std/blob": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/@web-std/blob/-/blob-2.1.2.tgz",
-                    "integrity": "sha512-Twhh3jpfvi9zMKYm6MElqLLsgUoXN5aG/qGgqB6ng2kNzPIZATMwUxSMcJV3Fs3U5dTOjEVk4m8mK4RGCpclYg==",
-                    "requires": {
-                        "web-encoding": "1.1.5",
-                        "web-streams-polyfill": "3.0.3"
-                    }
-                },
-                "@web-std/fetch": {
-                    "version": "2.0.2",
-                    "resolved": "https://registry.npmjs.org/@web-std/fetch/-/fetch-2.0.2.tgz",
-                    "integrity": "sha512-eMFIu4usBJDZD3CjIzTJxtS8Un8K9aeLjwbGsyW+te4eyDaknd2XHECWgeQkWZjQ69K2g9LJ8XdvA9GPKFAU9g==",
-                    "requires": {
-                        "@web-std/blob": "^2.1.0",
-                        "data-uri-to-buffer": "^3.0.1",
-                        "web-streams-polyfill": "^3.0.2"
-                    }
-                },
-                "@web-std/file": {
-                    "version": "1.1.1",
-                    "resolved": "https://registry.npmjs.org/@web-std/file/-/file-1.1.1.tgz",
-                    "integrity": "sha512-ZrmLDdCGsmj1MRBLhAa7lEbd2edi6os7A9VGfkOAum5EqdK6nPCWIeZPsk8KaSsLDkw0P2rbnITiT/mdkB8fEA==",
-                    "requires": {
-                        "@web-std/blob": "^2.1.0"
-                    }
-                },
-                "@zxing/text-encoding": {
-                    "version": "0.9.0",
-                    "resolved": "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz",
-                    "integrity": "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==",
-                    "optional": true
-                },
-                "abort-controller": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-                    "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-                    "requires": {
-                        "event-target-shim": "^5.0.0"
-                    }
-                },
-                "ansi-styles": {
-                    "version": "3.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-                    "requires": {
-                        "color-convert": "^1.9.0"
-                    }
-                },
-                "any-signal": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/any-signal/-/any-signal-2.1.2.tgz",
-                    "integrity": "sha512-B+rDnWasMi/eWcajPcCWSlYc7muXOrcYrqgyzcdKisl2H/WTlQ0gip1KyQfr0ZlxJdsuWCj/LWwQm7fhyhRfIQ==",
-                    "requires": {
-                        "abort-controller": "^3.0.0",
-                        "native-abort-controller": "^1.0.3"
-                    }
-                },
-                "arrify": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-                    "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
-                },
-                "available-typed-arrays": {
-                    "version": "1.0.4",
-                    "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.4.tgz",
-                    "integrity": "sha512-SA5mXJWrId1TaQjfxUYghbqQ/hYioKmLJvPJyDuYRtXXenFNMjj4hSSt1Cf1xsuXSXrtxrVC5Ot4eU6cOtBDdA=="
-                },
-                "balanced-match": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-                    "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
-                },
-                "base64-js": {
-                    "version": "1.5.1",
-                    "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-                    "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
-                },
-                "bl": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/bl/-/bl-5.0.0.tgz",
-                    "integrity": "sha512-8vxFNZ0pflFfi0WXA3WQXlj6CaMEwsmh63I1CNp0q+wWv8sD0ARx1KovSQd0l2GkwrMIOyedq0EF1FxI+RCZLQ==",
-                    "requires": {
-                        "buffer": "^6.0.3",
-                        "inherits": "^2.0.4",
-                        "readable-stream": "^3.4.0"
-                    }
-                },
-                "blob-to-it": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/blob-to-it/-/blob-to-it-1.0.2.tgz",
-                    "integrity": "sha512-yD8tikfTlUGEOSHExz4vDCIQFLaBPXIL0KcxGQt9RbwMVXBEh+jokdJyStvTXPgWrdKfwgk7RX8GPsgrYzsyng==",
-                    "requires": {
-                        "browser-readablestream-to-it": "^1.0.2"
-                    }
-                },
-                "brace-expansion": {
-                    "version": "1.1.11",
-                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-                    "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-                    "requires": {
-                        "balanced-match": "^1.0.0",
-                        "concat-map": "0.0.1"
-                    }
-                },
-                "browser-readablestream-to-it": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/browser-readablestream-to-it/-/browser-readablestream-to-it-1.0.2.tgz",
-                    "integrity": "sha512-lv4M2Z6RKJpyJijJzBQL5MNssS7i8yedl+QkhnLCyPtgNGNSXv1KthzUnye9NlRAtBAI80X6S9i+vK09Rzjcvg=="
-                },
-                "buffer": {
-                    "version": "6.0.3",
-                    "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-                    "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-                    "requires": {
-                        "base64-js": "^1.3.1",
-                        "ieee754": "^1.2.1"
-                    }
-                },
-                "call-bind": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-                    "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-                    "requires": {
-                        "function-bind": "^1.1.1",
-                        "get-intrinsic": "^1.0.2"
-                    }
-                },
-                "camelcase": {
-                    "version": "5.3.1",
-                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-                    "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
-                },
-                "camelcase-keys": {
-                    "version": "6.2.2",
-                    "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
-                    "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
-                    "requires": {
-                        "camelcase": "^5.3.1",
-                        "map-obj": "^4.0.0",
-                        "quick-lru": "^4.0.1"
-                    }
-                },
-                "carbites": {
-                    "version": "1.0.6",
-                    "resolved": "https://registry.npmjs.org/carbites/-/carbites-1.0.6.tgz",
-                    "integrity": "sha512-dS9IQvnrb5VIRvSTNz5Ff+mB9d2MFfi5mojtJi7Rlss79VeF190jr0sZdA7eW0CGHotvHkZaWuM6wgfD9PEFRg==",
-                    "requires": {
-                        "@ipld/car": "^3.0.1",
-                        "@ipld/dag-cbor": "^6.0.3",
-                        "@ipld/dag-pb": "^2.0.2",
-                        "multiformats": "^9.0.4"
-                    }
-                },
-                "cborg": {
-                    "version": "1.3.6",
-                    "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.3.6.tgz",
-                    "integrity": "sha512-PsJqI9K9uieA4dqCfVb5gzWI0EO0axzr+LCWrETc0YmzqkLQswtVeDfhJcD7pTmkSjaVlwcQ3BybT7gcmIDMFw=="
-                },
-                "chalk": {
-                    "version": "2.4.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-                    "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
-                    }
-                },
-                "cids": {
-                    "version": "1.1.7",
-                    "resolved": "https://registry.npmjs.org/cids/-/cids-1.1.7.tgz",
-                    "integrity": "sha512-dlh+K0hMwFAFFjWQ2ZzxOhgGVNVREPdmk8cqHFui2U4sOodcemLMxdE5Ujga4cDcDQhWfldEPThkfu6KWBt1eA==",
-                    "requires": {
-                        "multibase": "^4.0.1",
-                        "multicodec": "^3.0.1",
-                        "multihashes": "^4.0.1",
-                        "uint8arrays": "^2.1.3"
-                    }
-                },
-                "color-convert": {
-                    "version": "1.9.3",
-                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-                    "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-                    "requires": {
-                        "color-name": "1.1.3"
-                    }
-                },
-                "color-name": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-                    "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-                },
-                "concat-map": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                    "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-                },
-                "data-uri-to-buffer": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
-                    "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og=="
-                },
-                "debug": {
-                    "version": "4.3.2",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-                    "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-                    "requires": {
-                        "ms": "2.1.2"
-                    }
-                },
-                "decamelize": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-                    "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
-                },
-                "decamelize-keys": {
-                    "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
-                    "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
-                    "requires": {
-                        "decamelize": "^1.1.0",
-                        "map-obj": "^1.0.0"
-                    },
-                    "dependencies": {
-                        "map-obj": {
-                            "version": "1.0.1",
-                            "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-                            "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
-                        }
-                    }
-                },
-                "define-properties": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-                    "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-                    "requires": {
-                        "object-keys": "^1.0.12"
-                    }
-                },
-                "dns-over-http-resolver": {
-                    "version": "1.2.3",
-                    "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-1.2.3.tgz",
-                    "integrity": "sha512-miDiVSI6KSNbi4SVifzO/reD8rMnxgrlnkrlkugOLQpWQTe2qMdHsZp5DmfKjxNE+/T3VAAYLQUZMv9SMr6+AA==",
-                    "requires": {
-                        "debug": "^4.3.1",
-                        "native-fetch": "^3.0.0",
-                        "receptacle": "^1.3.2"
-                    }
-                },
-                "electron-fetch": {
-                    "version": "1.7.3",
-                    "resolved": "https://registry.npmjs.org/electron-fetch/-/electron-fetch-1.7.3.tgz",
-                    "integrity": "sha512-1AVMaxrHXTTMqd7EK0MGWusdqNr07Rpj8Th6bG4at0oNgIi/1LBwa9CjT/0Zy+M0k/tSJPS04nFxHj0SXDVgVw==",
-                    "requires": {
-                        "encoding": "^0.1.13"
-                    }
-                },
-                "encoding": {
-                    "version": "0.1.13",
-                    "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-                    "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-                    "requires": {
-                        "iconv-lite": "^0.6.2"
-                    }
-                },
-                "err-code": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/err-code/-/err-code-3.0.1.tgz",
-                    "integrity": "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA=="
-                },
-                "error-ex": {
-                    "version": "1.3.2",
-                    "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-                    "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-                    "requires": {
-                        "is-arrayish": "^0.2.1"
-                    }
-                },
-                "es-abstract": {
-                    "version": "1.18.3",
-                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.3.tgz",
-                    "integrity": "sha512-nQIr12dxV7SSxE6r6f1l3DtAeEYdsGpps13dR0TwJg1S8gyp4ZPgy3FZcHBgbiQqnoqSTb+oC+kO4UQ0C/J8vw==",
-                    "requires": {
-                        "call-bind": "^1.0.2",
-                        "es-to-primitive": "^1.2.1",
-                        "function-bind": "^1.1.1",
-                        "get-intrinsic": "^1.1.1",
-                        "has": "^1.0.3",
-                        "has-symbols": "^1.0.2",
-                        "is-callable": "^1.2.3",
-                        "is-negative-zero": "^2.0.1",
-                        "is-regex": "^1.1.3",
-                        "is-string": "^1.0.6",
-                        "object-inspect": "^1.10.3",
-                        "object-keys": "^1.1.1",
-                        "object.assign": "^4.1.2",
-                        "string.prototype.trimend": "^1.0.4",
-                        "string.prototype.trimstart": "^1.0.4",
-                        "unbox-primitive": "^1.0.1"
-                    }
-                },
-                "es-to-primitive": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-                    "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-                    "requires": {
-                        "is-callable": "^1.1.4",
-                        "is-date-object": "^1.0.1",
-                        "is-symbol": "^1.0.2"
-                    }
-                },
-                "escape-string-regexp": {
-                    "version": "1.0.5",
-                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                    "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-                },
-                "event-target-shim": {
-                    "version": "5.0.1",
-                    "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-                    "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
-                },
-                "events": {
-                    "version": "3.3.0",
-                    "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-                    "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
-                },
-                "fast-fifo": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.0.0.tgz",
-                    "integrity": "sha512-4VEXmjxLj7sbs8J//cn2qhRap50dGzF5n8fjay8mau+Jn4hxSeR3xPFwxMaQq/pDaq7+KQk0PAbC2+nWDkJrmQ=="
-                },
-                "files-from-path": {
-                    "version": "0.2.0",
-                    "resolved": "https://registry.npmjs.org/files-from-path/-/files-from-path-0.2.0.tgz",
-                    "integrity": "sha512-543OAjeBvPyInmEU4+4E6J/R1jR0yfR0MUsbOHGLruYv5PtnPxOGP0rj71a5DOE3aduKkRUpo5gFxcaeJLVcJw==",
-                    "requires": {
-                        "err-code": "^3.0.1",
-                        "it-glob": "^0.0.13"
-                    }
-                },
-                "find-up": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-                    "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-                    "requires": {
-                        "locate-path": "^5.0.0",
-                        "path-exists": "^4.0.0"
-                    }
-                },
-                "foreach": {
-                    "version": "2.0.5",
-                    "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-                    "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
-                },
-                "function-bind": {
-                    "version": "1.1.1",
-                    "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-                    "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
-                },
-                "get-intrinsic": {
-                    "version": "1.1.1",
-                    "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-                    "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
-                    "requires": {
-                        "function-bind": "^1.1.1",
-                        "has": "^1.0.3",
-                        "has-symbols": "^1.0.1"
-                    }
-                },
-                "get-iterator": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/get-iterator/-/get-iterator-1.0.2.tgz",
-                    "integrity": "sha512-v+dm9bNVfOYsY1OrhaCrmyOcYoSeVvbt+hHZ0Au+T+p1y+0Uyj9aMaGIeUTT6xdpRbWzDeYKvfOslPhggQMcsg=="
-                },
-                "hamt-sharding": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/hamt-sharding/-/hamt-sharding-2.0.0.tgz",
-                    "integrity": "sha512-h8HKkMrqX6UC7I8hYRA1BT8pSC1TV1+V9HolGyWiNKRIztMQ980vWwjWZSLPFHtUKGMtOVBSVz5lIXuvlzwlWQ==",
-                    "requires": {
-                        "sparse-array": "^1.3.1",
-                        "uint8arrays": "^2.1.2"
-                    }
-                },
-                "hard-rejection": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
-                    "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA=="
-                },
-                "has": {
-                    "version": "1.0.3",
-                    "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-                    "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-                    "requires": {
-                        "function-bind": "^1.1.1"
-                    }
-                },
-                "has-bigints": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
-                    "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA=="
-                },
-                "has-flag": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
-                },
-                "has-symbols": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-                    "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
-                },
-                "hosted-git-info": {
-                    "version": "4.0.2",
-                    "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.2.tgz",
-                    "integrity": "sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==",
-                    "requires": {
-                        "lru-cache": "^6.0.0"
-                    }
-                },
-                "iconv-lite": {
-                    "version": "0.6.3",
-                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-                    "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-                    "requires": {
-                        "safer-buffer": ">= 2.1.2 < 3.0.0"
-                    }
-                },
-                "idb-keyval": {
-                    "version": "5.0.6",
-                    "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-5.0.6.tgz",
-                    "integrity": "sha512-6lJuVbwyo82mKSH6Wq2eHkt9LcbwHAelMIcMe0tP4p20Pod7tTxq9zf0ge2n/YDfMOpDryerfmmYyuQiaFaKOg=="
-                },
-                "ieee754": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-                    "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
-                },
-                "indent-string": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-                    "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
-                },
-                "inherits": {
-                    "version": "2.0.4",
-                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-                    "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-                },
-                "interface-blockstore": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/interface-blockstore/-/interface-blockstore-1.0.0.tgz",
-                    "integrity": "sha512-wkBezBLWF7BuXAOljfdj0H2xWy7pW8Y5mQlv7HqI1wKcUmVVXNa9XGPAF8j/HQ1ZbjJdftISAD932Q4AFgG0zg==",
-                    "requires": {
-                        "err-code": "^3.0.1",
-                        "interface-store": "^0.1.1",
-                        "it-all": "^1.0.5",
-                        "it-drain": "^1.0.4",
-                        "it-filter": "^1.0.2",
-                        "it-take": "^1.0.1",
-                        "multiformats": "^9.0.4"
-                    }
-                },
-                "interface-datastore": {
-                    "version": "4.0.2",
-                    "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-4.0.2.tgz",
-                    "integrity": "sha512-/XRmD7oagZMTaK25rV3WFrejLoUwxZcpgE+eNyZNYvb2jlB5P3MwJCIbetJSlVYK7yvaFmJi8s3f9VLcxJjdog==",
-                    "requires": {
-                        "err-code": "^3.0.1",
-                        "interface-store": "^0.0.2",
-                        "ipfs-utils": "^8.1.2",
-                        "iso-random-stream": "^2.0.0",
-                        "it-all": "^1.0.2",
-                        "it-drain": "^1.0.1",
-                        "it-filter": "^1.0.2",
-                        "it-take": "^1.0.1",
-                        "nanoid": "^3.0.2",
-                        "uint8arrays": "^2.1.5"
-                    },
-                    "dependencies": {
-                        "interface-store": {
-                            "version": "0.0.2",
-                            "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-0.0.2.tgz",
-                            "integrity": "sha512-t4c9GKXH1Vi/WxmppGyIi6iedbGo92YmLneopHmbIEIp27ep7VnrYGA6lM/rLsFo5Tj6TJgIqr3FOk8mvPgIWQ=="
-                        }
-                    }
-                },
-                "interface-store": {
-                    "version": "0.1.1",
-                    "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-0.1.1.tgz",
-                    "integrity": "sha512-ynnjIOybDZc0Brep3HHSa2RVlo/M5g7kuL/leui7o21EusKcLJS170vCJ8rliisc3c4jyd9ao5PthkGlBaX29g=="
-                },
-                "ip-regex": {
-                    "version": "4.3.0",
-                    "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
-                    "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q=="
-                },
-                "ipfs-car": {
-                    "version": "0.5.1",
-                    "resolved": "https://registry.npmjs.org/ipfs-car/-/ipfs-car-0.5.1.tgz",
-                    "integrity": "sha512-axX7c7/sBINJYI6jEvUFybO4TJ5nKdj3FTKBh+1zPm8atu421btgCqkrN0pAXXNl4z+cqSFlDIdFzJOVzfnj1w==",
-                    "requires": {
-                        "@ipld/car": "^3.1.4",
-                        "@web-std/blob": "^2.1.1",
-                        "bl": "^5.0.0",
-                        "idb-keyval": "^5.0.6",
-                        "interface-blockstore": "^1.0.0",
-                        "ipfs-core-types": "^0.5.2",
-                        "ipfs-core-utils": "^0.8.0",
-                        "ipfs-unixfs-exporter": "^6.0.0",
-                        "ipfs-unixfs-importer": "^8.0.0",
-                        "ipfs-utils": "^8.1.0",
-                        "it-all": "^1.0.5",
-                        "it-last": "^1.0.5",
-                        "it-pipe": "^1.1.0",
-                        "meow": "^9.0.0",
-                        "move-file": "^2.1.0",
-                        "multiformats": "^9.3.0",
-                        "stream-to-it": "^0.2.3",
-                        "streaming-iterables": "^6.0.0",
-                        "uint8arrays": "^2.1.5"
-                    }
-                },
-                "ipfs-core-types": {
-                    "version": "0.5.2",
-                    "resolved": "https://registry.npmjs.org/ipfs-core-types/-/ipfs-core-types-0.5.2.tgz",
-                    "integrity": "sha512-DOQeL+GFGYMTlnbdtMeBzvfVnyAalSgCfPr8XUCI+FVBZZWwzkt5jZZzGDmF87HVRrMR3FuVyBKZj772mcXKyQ==",
-                    "requires": {
-                        "cids": "^1.1.6",
-                        "interface-datastore": "^4.0.0",
-                        "ipld-block": "^0.11.1",
-                        "multiaddr": "^9.0.1",
-                        "multibase": "^4.0.2"
-                    }
-                },
-                "ipfs-core-utils": {
-                    "version": "0.8.3",
-                    "resolved": "https://registry.npmjs.org/ipfs-core-utils/-/ipfs-core-utils-0.8.3.tgz",
-                    "integrity": "sha512-PY7PkCgCtVYtNOe1C3ew1+5D9NqXqizb886R/lyGWe+KsmWtBQkQIk0ZIDwKyHGvG2KA2QQeIDzdOmzBQBJtHQ==",
-                    "requires": {
-                        "any-signal": "^2.1.2",
-                        "blob-to-it": "^1.0.1",
-                        "browser-readablestream-to-it": "^1.0.1",
-                        "cids": "^1.1.6",
-                        "err-code": "^3.0.1",
-                        "ipfs-core-types": "^0.5.2",
-                        "ipfs-unixfs": "^4.0.3",
-                        "ipfs-utils": "^8.1.2",
-                        "it-all": "^1.0.4",
-                        "it-map": "^1.0.4",
-                        "it-peekable": "^1.0.1",
-                        "multiaddr": "^9.0.1",
-                        "multiaddr-to-uri": "^7.0.0",
-                        "parse-duration": "^1.0.0",
-                        "timeout-abort-controller": "^1.1.1",
-                        "uint8arrays": "^2.1.3"
-                    }
-                },
-                "ipfs-unixfs": {
-                    "version": "4.0.3",
-                    "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-4.0.3.tgz",
-                    "integrity": "sha512-hzJ3X4vlKT8FQ3Xc4M1szaFVjsc1ZydN+E4VQ91aXxfpjFn9G2wsMo1EFdAXNq/BUnN5dgqIOMP5zRYr3DTsAw==",
-                    "requires": {
-                        "err-code": "^3.0.1",
-                        "protobufjs": "^6.10.2"
-                    }
-                },
-                "ipfs-unixfs-exporter": {
-                    "version": "6.0.1",
-                    "resolved": "https://registry.npmjs.org/ipfs-unixfs-exporter/-/ipfs-unixfs-exporter-6.0.1.tgz",
-                    "integrity": "sha512-lVmCIByxJV5llUHBLC/iRFLP/s07iJl0hA5oofYP6SMUOeNiyZmY6ceMQnZHaFHRlkcg2giC0qnJvO2fNhdY5w==",
-                    "requires": {
-                        "@ipld/dag-cbor": "^6.0.4",
-                        "@ipld/dag-pb": "^2.0.2",
-                        "err-code": "^3.0.1",
-                        "hamt-sharding": "^2.0.0",
-                        "interface-blockstore": "^1.0.0",
-                        "ipfs-unixfs": "^5.0.0",
-                        "it-last": "^1.0.5",
-                        "multiformats": "^9.4.2",
-                        "murmurhash3js-revisited": "^3.0.0",
-                        "uint8arrays": "^2.1.7"
-                    },
-                    "dependencies": {
-                        "ipfs-unixfs": {
-                            "version": "5.0.0",
-                            "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-5.0.0.tgz",
-                            "integrity": "sha512-6FpBtsxB/9R7o7LGmSMaIoYkWO/cK+JYcj22QYIZaiA5dlk28Dvqme18bA43A7UKEc0M8I7mwD92ZXrlhJ/C7Q==",
-                            "requires": {
-                                "err-code": "^3.0.1",
-                                "protobufjs": "^6.10.2"
-                            }
-                        }
-                    }
-                },
-                "ipfs-unixfs-importer": {
-                    "version": "8.0.1",
-                    "resolved": "https://registry.npmjs.org/ipfs-unixfs-importer/-/ipfs-unixfs-importer-8.0.1.tgz",
-                    "integrity": "sha512-k7TW6R8vMyDffl5sZeZ9JYIJslvpYtjVdF0bX8fESAOr+/L3PsqA9ZfssDjPlRqJbZz6qKqMDcx1oWUCaJ4cgA==",
-                    "requires": {
-                        "@ipld/dag-pb": "^2.0.2",
-                        "bl": "^5.0.0",
-                        "err-code": "^3.0.1",
-                        "hamt-sharding": "^2.0.0",
-                        "interface-blockstore": "^1.0.0",
-                        "ipfs-unixfs": "^5.0.0",
-                        "it-all": "^1.0.5",
-                        "it-batch": "^1.0.8",
-                        "it-first": "^1.0.6",
-                        "it-parallel-batch": "^1.0.9",
-                        "merge-options": "^3.0.4",
-                        "multiformats": "^9.4.2",
-                        "murmurhash3js-revisited": "^3.0.0",
-                        "rabin-wasm": "^0.1.4",
-                        "uint8arrays": "^2.1.7"
-                    },
-                    "dependencies": {
-                        "ipfs-unixfs": {
-                            "version": "5.0.0",
-                            "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-5.0.0.tgz",
-                            "integrity": "sha512-6FpBtsxB/9R7o7LGmSMaIoYkWO/cK+JYcj22QYIZaiA5dlk28Dvqme18bA43A7UKEc0M8I7mwD92ZXrlhJ/C7Q==",
-                            "requires": {
-                                "err-code": "^3.0.1",
-                                "protobufjs": "^6.10.2"
-                            }
-                        }
-                    }
-                },
-                "ipfs-utils": {
-                    "version": "8.1.4",
-                    "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-8.1.4.tgz",
-                    "integrity": "sha512-QJjyRh4KzlkmtAOn/fOHYyjHGuG+Ows7xJGG8eiM/v325VvJhjJ1tWJobI6zrNDeFKjZcx1uNysE3MR2/dSiXQ==",
-                    "requires": {
-                        "abort-controller": "^3.0.0",
-                        "any-signal": "^2.1.0",
-                        "buffer": "^6.0.1",
-                        "electron-fetch": "^1.7.2",
-                        "err-code": "^3.0.1",
-                        "is-electron": "^2.2.0",
-                        "iso-url": "^1.1.5",
-                        "it-glob": "~0.0.11",
-                        "it-to-stream": "^1.0.0",
-                        "merge-options": "^3.0.4",
-                        "nanoid": "^3.1.20",
-                        "native-abort-controller": "^1.0.3",
-                        "native-fetch": "^3.0.0",
-                        "node-fetch": "npm:@achingbrain/node-fetch@^2.6.4",
-                        "react-native-fetch-api": "^2.0.0",
-                        "stream-to-it": "^0.2.2"
-                    }
-                },
-                "ipld-block": {
-                    "version": "0.11.1",
-                    "resolved": "https://registry.npmjs.org/ipld-block/-/ipld-block-0.11.1.tgz",
-                    "integrity": "sha512-sDqqLqD5qh4QzGq6ssxLHUCnH4emCf/8F8IwjQM2cjEEIEHMUj57XhNYgmGbemdYPznUhffxFGEHsruh5+HQRw==",
-                    "requires": {
-                        "cids": "^1.0.0"
-                    }
-                },
-                "is-arguments": {
-                    "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.0.tgz",
-                    "integrity": "sha512-1Ij4lOMPl/xB5kBDn7I+b2ttPMKa8szhEIrXDuXQD/oe3HJLTLhqhgGspwgyGd6MOywBUqVvYicF72lkgDnIHg==",
-                    "requires": {
-                        "call-bind": "^1.0.0"
-                    }
-                },
-                "is-arrayish": {
-                    "version": "0.2.1",
-                    "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-                    "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
-                },
-                "is-bigint": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.2.tgz",
-                    "integrity": "sha512-0JV5+SOCQkIdzjBK9buARcV804Ddu7A0Qet6sHi3FimE9ne6m4BGQZfRn+NZiXbBk4F4XmHfDZIipLj9pX8dSA=="
-                },
-                "is-boolean-object": {
-                    "version": "1.1.1",
-                    "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.1.tgz",
-                    "integrity": "sha512-bXdQWkECBUIAcCkeH1unwJLIpZYaa5VvuygSyS/c2lf719mTKZDU5UdDRlpd01UjADgmW8RfqaP+mRaVPdr/Ng==",
-                    "requires": {
-                        "call-bind": "^1.0.2"
-                    }
-                },
-                "is-callable": {
-                    "version": "1.2.3",
-                    "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
-                    "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ=="
-                },
-                "is-core-module": {
-                    "version": "2.5.0",
-                    "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.5.0.tgz",
-                    "integrity": "sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==",
-                    "requires": {
-                        "has": "^1.0.3"
-                    }
-                },
-                "is-date-object": {
-                    "version": "1.0.4",
-                    "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.4.tgz",
-                    "integrity": "sha512-/b4ZVsG7Z5XVtIxs/h9W8nvfLgSAyKYdtGWQLbqy6jA1icmgjf8WCoTKgeS4wy5tYaPePouzFMANbnj94c2Z+A=="
-                },
-                "is-electron": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.0.tgz",
-                    "integrity": "sha512-SpMppC2XR3YdxSzczXReBjqs2zGscWQpBIKqwXYBFic0ERaxNVgwLCHwOLZeESfdJQjX0RDvrJ1lBXX2ij+G1Q=="
-                },
-                "is-generator-function": {
-                    "version": "1.0.9",
-                    "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.9.tgz",
-                    "integrity": "sha512-ZJ34p1uvIfptHCN7sFTjGibB9/oBg17sHqzDLfuwhvmN/qLVvIQXRQ8licZQ35WJ8KuEQt/etnnzQFI9C9Ue/A=="
-                },
-                "is-ip": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
-                    "integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
-                    "requires": {
-                        "ip-regex": "^4.0.0"
-                    }
-                },
-                "is-negative-zero": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
-                    "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w=="
-                },
-                "is-number-object": {
-                    "version": "1.0.5",
-                    "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.5.tgz",
-                    "integrity": "sha512-RU0lI/n95pMoUKu9v1BZP5MBcZuNSVJkMkAG2dJqC4z2GlkGUNeH68SuHuBKBD/XFe+LHZ+f9BKkLET60Niedw=="
-                },
-                "is-plain-obj": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-                    "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
-                },
-                "is-regex": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
-                    "integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
-                    "requires": {
-                        "call-bind": "^1.0.2",
-                        "has-symbols": "^1.0.2"
-                    }
-                },
-                "is-string": {
-                    "version": "1.0.6",
-                    "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.6.tgz",
-                    "integrity": "sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w=="
-                },
-                "is-symbol": {
-                    "version": "1.0.4",
-                    "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
-                    "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
-                    "requires": {
-                        "has-symbols": "^1.0.2"
-                    }
-                },
-                "is-typed-array": {
-                    "version": "1.1.5",
-                    "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.5.tgz",
-                    "integrity": "sha512-S+GRDgJlR3PyEbsX/Fobd9cqpZBuvUS+8asRqYDMLCb2qMzt1oz5m5oxQCxOgUDxiWsOVNi4yaF+/uvdlHlYug==",
-                    "requires": {
-                        "available-typed-arrays": "^1.0.2",
-                        "call-bind": "^1.0.2",
-                        "es-abstract": "^1.18.0-next.2",
-                        "foreach": "^2.0.5",
-                        "has-symbols": "^1.0.1"
-                    }
-                },
-                "iso-random-stream": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/iso-random-stream/-/iso-random-stream-2.0.0.tgz",
-                    "integrity": "sha512-lGuIu104KfBV9ubYTSaE3GeAr6I69iggXxBHbTBc5u/XKlwlWl0LCytnkIZissaKqvxablwRD9B3ktVnmIUnEg==",
-                    "requires": {
-                        "events": "^3.3.0",
-                        "readable-stream": "^3.4.0"
-                    }
-                },
-                "iso-url": {
-                    "version": "1.1.5",
-                    "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-1.1.5.tgz",
-                    "integrity": "sha512-+3JqoKdBTGmyv9vOkS6b9iHhvK34UajfTibrH/1HOK8TI7K2VsM0qOCd+aJdWKtSOA8g3PqZfcwDmnR0p3klqQ=="
-                },
-                "it-all": {
-                    "version": "1.0.5",
-                    "resolved": "https://registry.npmjs.org/it-all/-/it-all-1.0.5.tgz",
-                    "integrity": "sha512-ygD4kA4vp8fi+Y+NBgEKt6W06xSbv6Ub/0V8d1r3uCyJ9Izwa1UspkIOlqY9fOee0Z1w3WRo1+VWyAU4DgtufA=="
-                },
-                "it-batch": {
-                    "version": "1.0.8",
-                    "resolved": "https://registry.npmjs.org/it-batch/-/it-batch-1.0.8.tgz",
-                    "integrity": "sha512-RfEa1rxOPnicXvaXJ1qNThxPrq8/Lc+KwSVWHFEEOp2CrjpjhR5WfmBJozhkbzZ/r/Gl0HjzVVrt0NpG8qczDQ=="
-                },
-                "it-drain": {
-                    "version": "1.0.4",
-                    "resolved": "https://registry.npmjs.org/it-drain/-/it-drain-1.0.4.tgz",
-                    "integrity": "sha512-coB7mcyZ4lWBQKoQGJuqM+P94pvpn2T3KY27vcVWPqeB1WmoysRC76VZnzAqrBWzpWcoEJMjZ+fsMBslxNaWfQ=="
-                },
-                "it-filter": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/it-filter/-/it-filter-1.0.2.tgz",
-                    "integrity": "sha512-rxFUyPCrhk7WrNxD8msU10iEPhQmROoqwuyWmQUYY1PtopwUGBYyra9EYG2nRZADYeuT83cohKWmKCWPzpeyiw=="
-                },
-                "it-first": {
-                    "version": "1.0.6",
-                    "resolved": "https://registry.npmjs.org/it-first/-/it-first-1.0.6.tgz",
-                    "integrity": "sha512-wiI02c+G1BVuu0jz30Nsr1/et0cpSRulKUusN8HDZXxuX4MdUzfMp2P4JUk+a49Wr1kHitRLrnnh3+UzJ6neaQ=="
-                },
-                "it-glob": {
-                    "version": "0.0.13",
-                    "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-0.0.13.tgz",
-                    "integrity": "sha512-0Hcd5BraJUPzL28NWiFbdNrcdyNxNTKKdU3sjdFiYynNTQpwlG2UKW31X7bp+XhJwux/oPzIquo5ioztVmc2RQ==",
-                    "requires": {
-                        "@types/minimatch": "^3.0.4",
-                        "minimatch": "^3.0.4"
-                    }
-                },
-                "it-last": {
-                    "version": "1.0.5",
-                    "resolved": "https://registry.npmjs.org/it-last/-/it-last-1.0.5.tgz",
-                    "integrity": "sha512-PV/2S4zg5g6dkVuKfgrQfN2rUN4wdTI1FzyAvU+i8RV96syut40pa2s9Dut5X7SkjwA3P0tOhLABLdnOJ0Y/4Q=="
-                },
-                "it-map": {
-                    "version": "1.0.5",
-                    "resolved": "https://registry.npmjs.org/it-map/-/it-map-1.0.5.tgz",
-                    "integrity": "sha512-EElupuWhHVStUgUY+OfTJIS2MZed96lDrAXzJUuqiiqLnIKoBRqtX1ZG2oR0bGDsSppmz83MtzCeKLZ9TVAUxQ=="
-                },
-                "it-parallel-batch": {
-                    "version": "1.0.9",
-                    "resolved": "https://registry.npmjs.org/it-parallel-batch/-/it-parallel-batch-1.0.9.tgz",
-                    "integrity": "sha512-lfCxXsHoEtgyWj5HLrEQXlZF0p3c0hfYeVJAbxQIHIzHLq4lkYplUIe3UGxYl4n1Sjpcs6YL/87352399aVeIA==",
-                    "requires": {
-                        "it-batch": "^1.0.8"
-                    }
-                },
-                "it-peekable": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-1.0.2.tgz",
-                    "integrity": "sha512-LRPLu94RLm+lxLZbChuc9iCXrKCOu1obWqxfaKhF00yIp30VGkl741b5P60U+rdBxuZD/Gt1bnmakernv7bVFg=="
-                },
-                "it-pipe": {
-                    "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-1.1.0.tgz",
-                    "integrity": "sha512-lF0/3qTVeth13TOnHVs0BTFaziwQF7m5Gg+E6JV0BXcLKutC92YjSi7bASgkPOXaLEb+YvNZrPorGMBIJvZfxg=="
-                },
-                "it-take": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/it-take/-/it-take-1.0.1.tgz",
-                    "integrity": "sha512-6H6JAWYcyumKSpcIPLs6tHN4xnibphmyU79WQaYVCBtaBOzf4fn75wzvSH8fH8fcMlPBTWY1RlmOWleQxBt2Ug=="
-                },
-                "it-to-stream": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/it-to-stream/-/it-to-stream-1.0.0.tgz",
-                    "integrity": "sha512-pLULMZMAB/+vbdvbZtebC0nWBTbG581lk6w8P7DfIIIKUfa8FbY7Oi0FxZcFPbxvISs7A9E+cMpLDBc1XhpAOA==",
-                    "requires": {
-                        "buffer": "^6.0.3",
-                        "fast-fifo": "^1.0.0",
-                        "get-iterator": "^1.0.2",
-                        "p-defer": "^3.0.0",
-                        "p-fifo": "^1.0.0",
-                        "readable-stream": "^3.6.0"
-                    }
-                },
-                "js-tokens": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-                    "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
-                },
-                "json-parse-even-better-errors": {
-                    "version": "2.3.1",
-                    "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-                    "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
-                },
-                "kind-of": {
-                    "version": "6.0.3",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-                    "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
-                },
-                "lines-and-columns": {
-                    "version": "1.1.6",
-                    "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
-                    "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
-                },
-                "locate-path": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-                    "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-                    "requires": {
-                        "p-locate": "^4.1.0"
-                    }
-                },
-                "long": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-                    "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
-                },
-                "lru-cache": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-                    "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-                    "requires": {
-                        "yallist": "^4.0.0"
-                    }
-                },
-                "map-obj": {
-                    "version": "4.2.1",
-                    "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.2.1.tgz",
-                    "integrity": "sha512-+WA2/1sPmDj1dlvvJmB5G6JKfY9dpn7EVBUL06+y6PoljPkh+6V1QihwxNkbcGxCRjt2b0F9K0taiCuo7MbdFQ=="
-                },
-                "meow": {
-                    "version": "9.0.0",
-                    "resolved": "https://registry.npmjs.org/meow/-/meow-9.0.0.tgz",
-                    "integrity": "sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==",
-                    "requires": {
-                        "@types/minimist": "^1.2.0",
-                        "camelcase-keys": "^6.2.2",
-                        "decamelize": "^1.2.0",
-                        "decamelize-keys": "^1.1.0",
-                        "hard-rejection": "^2.1.0",
-                        "minimist-options": "4.1.0",
-                        "normalize-package-data": "^3.0.0",
-                        "read-pkg-up": "^7.0.1",
-                        "redent": "^3.0.0",
-                        "trim-newlines": "^3.0.0",
-                        "type-fest": "^0.18.0",
-                        "yargs-parser": "^20.2.3"
-                    }
-                },
-                "merge-options": {
-                    "version": "3.0.4",
-                    "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
-                    "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
-                    "requires": {
-                        "is-plain-obj": "^2.1.0"
-                    }
-                },
-                "min-indent": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
-                    "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="
-                },
-                "minimatch": {
-                    "version": "3.0.4",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-                    "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-                    "requires": {
-                        "brace-expansion": "^1.1.7"
-                    }
-                },
-                "minimist": {
-                    "version": "1.2.5",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-                    "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-                },
-                "minimist-options": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
-                    "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
-                    "requires": {
-                        "arrify": "^1.0.1",
-                        "is-plain-obj": "^1.1.0",
-                        "kind-of": "^6.0.3"
-                    },
-                    "dependencies": {
-                        "is-plain-obj": {
-                            "version": "1.1.0",
-                            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-                            "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
-                        }
-                    }
-                },
-                "move-file": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/move-file/-/move-file-2.1.0.tgz",
-                    "integrity": "sha512-i9qLW6gqboJ5Ht8bauZi7KlTnQ3QFpBCvMvFfEcHADKgHGeJ9BZMO7SFCTwHPV9Qa0du9DYY1Yx3oqlGt30nXA==",
-                    "requires": {
-                        "path-exists": "^4.0.0"
-                    }
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-                },
-                "multiaddr": {
-                    "version": "9.0.2",
-                    "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-9.0.2.tgz",
-                    "integrity": "sha512-YFaEb9t4yXSbaGksSEdg+Kn2U02s7w4wXUgyEMQmPxFJj7CfVHY10WOsScAX/rK6Soa15S1zXYadqH9TtlVreQ==",
-                    "requires": {
-                        "cids": "^1.0.0",
-                        "dns-over-http-resolver": "^1.0.0",
-                        "err-code": "^3.0.1",
-                        "is-ip": "^3.1.0",
-                        "multibase": "^4.0.2",
-                        "uint8arrays": "^2.1.3",
-                        "varint": "^6.0.0"
-                    }
-                },
-                "multiaddr-to-uri": {
-                    "version": "7.0.0",
-                    "resolved": "https://registry.npmjs.org/multiaddr-to-uri/-/multiaddr-to-uri-7.0.0.tgz",
-                    "integrity": "sha512-VbscDpLcbV0m25tJqfnZSfbjVUuNlPa4BbD5l/7me1t0lc3SWI0XAoO5E/PNJF0e1qUlbdq7yjVFEQjUT+9r0g==",
-                    "requires": {
-                        "multiaddr": "^9.0.1"
-                    }
-                },
-                "multibase": {
-                    "version": "4.0.4",
-                    "resolved": "https://registry.npmjs.org/multibase/-/multibase-4.0.4.tgz",
-                    "integrity": "sha512-8/JmrdSGzlw6KTgAJCOqUBSGd1V6186i/X8dDCGy/lbCKrQ+1QB6f3HE+wPr7Tpdj4U3gutaj9jG2rNX6UpiJg==",
-                    "requires": {
-                        "@multiformats/base-x": "^4.0.1"
-                    }
-                },
-                "multicodec": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-3.1.0.tgz",
-                    "integrity": "sha512-f6d4DhbQ9a8WiJ/wpbKgeJSeR0/juP/1wnjbKdZ0KAWDkC/z7Lb3xOegMUG+uTcfwSYf6j1eTvFf8HDgqPRGmQ==",
-                    "requires": {
-                        "uint8arrays": "^2.1.5",
-                        "varint": "^6.0.0"
-                    }
-                },
-                "multiformats": {
-                    "version": "9.4.3",
-                    "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.4.3.tgz",
-                    "integrity": "sha512-sCNjBP/NPCeQu83Mst8IQZq9+HuR7Catvk/m7CeH0r/nupsU6gM7GINf5E1HCDRxDeU+Cgda/WPmcwQhYs3dyA=="
-                },
-                "multihashes": {
-                    "version": "4.0.2",
-                    "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-4.0.2.tgz",
-                    "integrity": "sha512-xpx++1iZr4ZQHjN1mcrXS6904R36LWLxX/CBifczjtmrtCXEX623DMWOF1eiNSg+pFpiZDFVBgou/4v6ayCHSQ==",
-                    "requires": {
-                        "multibase": "^4.0.1",
-                        "uint8arrays": "^2.1.3",
-                        "varint": "^5.0.2"
-                    },
-                    "dependencies": {
-                        "varint": {
-                            "version": "5.0.2",
-                            "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
-                            "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
-                        }
-                    }
-                },
-                "murmurhash3js-revisited": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/murmurhash3js-revisited/-/murmurhash3js-revisited-3.0.0.tgz",
-                    "integrity": "sha512-/sF3ee6zvScXMb1XFJ8gDsSnY+X8PbOyjIuBhtgis10W2Jx4ZjIhikUCIF9c4gpJxVnQIsPAFrSwTCuAjicP6g=="
-                },
-                "nanoid": {
-                    "version": "3.1.23",
-                    "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
-                    "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw=="
-                },
-                "native-abort-controller": {
-                    "version": "1.0.3",
-                    "resolved": "https://registry.npmjs.org/native-abort-controller/-/native-abort-controller-1.0.3.tgz",
-                    "integrity": "sha512-fd5LY5q06mHKZPD5FmMrn7Lkd2H018oBGKNOAdLpctBDEPFKsfJ1nX9ke+XRa8PEJJpjqrpQkGjq2IZ27QNmYA=="
-                },
-                "native-fetch": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-3.0.0.tgz",
-                    "integrity": "sha512-G3Z7vx0IFb/FQ4JxvtqGABsOTIqRWvgQz6e+erkB+JJD6LrszQtMozEHI4EkmgZQvnGHrpLVzUWk7t4sJCIkVw=="
-                },
-                "node-fetch": {
-                    "version": "npm:@achingbrain/node-fetch@2.6.7",
-                    "resolved": "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz",
-                    "integrity": "sha512-iTASGs+HTFK5E4ZqcMsHmeJ4zodyq8L38lZV33jwqcBJYoUt3HjN4+ot+O9/0b+ke8ddE7UgOtVuZN/OkV19/g=="
-                },
-                "normalize-package-data": {
-                    "version": "3.0.2",
-                    "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.2.tgz",
-                    "integrity": "sha512-6CdZocmfGaKnIHPVFhJJZ3GuR8SsLKvDANFp47Jmy51aKIr8akjAWTSxtpI+MBgBFdSMRyo4hMpDlT6dTffgZg==",
-                    "requires": {
-                        "hosted-git-info": "^4.0.1",
-                        "resolve": "^1.20.0",
-                        "semver": "^7.3.4",
-                        "validate-npm-package-license": "^3.0.1"
-                    }
-                },
-                "object-inspect": {
-                    "version": "1.11.0",
-                    "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
-                    "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg=="
-                },
-                "object-keys": {
-                    "version": "1.1.1",
-                    "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-                    "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
-                },
-                "object.assign": {
-                    "version": "4.1.2",
-                    "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-                    "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-                    "requires": {
-                        "call-bind": "^1.0.0",
-                        "define-properties": "^1.1.3",
-                        "has-symbols": "^1.0.1",
-                        "object-keys": "^1.1.1"
-                    }
-                },
-                "p-defer": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
-                    "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
-                },
-                "p-fifo": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/p-fifo/-/p-fifo-1.0.0.tgz",
-                    "integrity": "sha512-IjoCxXW48tqdtDFz6fqo5q1UfFVjjVZe8TC1QRflvNUJtNfCUhxOUw6MOVZhDPjqhSzc26xKdugsO17gmzd5+A==",
-                    "requires": {
-                        "fast-fifo": "^1.0.0",
-                        "p-defer": "^3.0.0"
-                    }
-                },
-                "p-limit": {
-                    "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-                    "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-                    "requires": {
-                        "p-try": "^2.0.0"
-                    }
-                },
-                "p-locate": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-                    "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-                    "requires": {
-                        "p-limit": "^2.2.0"
-                    }
-                },
-                "p-retry": {
-                    "version": "4.6.1",
-                    "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.1.tgz",
-                    "integrity": "sha512-e2xXGNhZOZ0lfgR9kL34iGlU8N/KO0xZnQxVEwdeOvpqNDQfdnxIYizvWtK8RglUa3bGqI8g0R/BdfzLMxRkiA==",
-                    "requires": {
-                        "@types/retry": "^0.12.0",
-                        "retry": "^0.13.1"
-                    }
-                },
-                "p-try": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-                    "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
-                },
-                "parse-duration": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/parse-duration/-/parse-duration-1.0.0.tgz",
-                    "integrity": "sha512-X4kUkCTHU1N/kEbwK9FpUJ0UZQa90VzeczfS704frR30gljxDG0pSziws06XlK+CGRSo/1wtG1mFIdBFQTMQNw=="
-                },
-                "parse-json": {
-                    "version": "5.2.0",
-                    "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-                    "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-                    "requires": {
-                        "@babel/code-frame": "^7.0.0",
-                        "error-ex": "^1.3.1",
-                        "json-parse-even-better-errors": "^2.3.0",
-                        "lines-and-columns": "^1.1.6"
-                    }
-                },
-                "path-exists": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-                    "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
-                },
-                "path-parse": {
-                    "version": "1.0.7",
-                    "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-                    "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
-                },
-                "protobufjs": {
-                    "version": "6.11.2",
-                    "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.2.tgz",
-                    "integrity": "sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==",
-                    "requires": {
-                        "@protobufjs/aspromise": "^1.1.2",
-                        "@protobufjs/base64": "^1.1.2",
-                        "@protobufjs/codegen": "^2.0.4",
-                        "@protobufjs/eventemitter": "^1.1.0",
-                        "@protobufjs/fetch": "^1.1.0",
-                        "@protobufjs/float": "^1.0.2",
-                        "@protobufjs/inquire": "^1.1.0",
-                        "@protobufjs/path": "^1.1.2",
-                        "@protobufjs/pool": "^1.1.0",
-                        "@protobufjs/utf8": "^1.1.0",
-                        "@types/long": "^4.0.1",
-                        "@types/node": ">=13.7.0",
-                        "long": "^4.0.0"
-                    }
-                },
-                "quick-lru": {
-                    "version": "4.0.1",
-                    "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
-                    "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g=="
-                },
-                "rabin-wasm": {
-                    "version": "0.1.5",
-                    "resolved": "https://registry.npmjs.org/rabin-wasm/-/rabin-wasm-0.1.5.tgz",
-                    "integrity": "sha512-uWgQTo7pim1Rnj5TuWcCewRDTf0PEFTSlaUjWP4eY9EbLV9em08v89oCz/WO+wRxpYuO36XEHp4wgYQnAgOHzA==",
-                    "requires": {
-                        "@assemblyscript/loader": "^0.9.4",
-                        "bl": "^5.0.0",
-                        "debug": "^4.3.1",
-                        "minimist": "^1.2.5",
-                        "node-fetch": "^2.6.1",
-                        "readable-stream": "^3.6.0"
-                    }
-                },
-                "react-native-fetch-api": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/react-native-fetch-api/-/react-native-fetch-api-2.0.0.tgz",
-                    "integrity": "sha512-GOA8tc1EVYLnHvma/TU9VTgLOyralO7eATRuCDchQveXW9Fr9vXygyq9iwqmM7YRZ8qRJfEt9xOS7OYMdJvRFw==",
-                    "requires": {
-                        "p-defer": "^3.0.0"
-                    }
-                },
-                "read-pkg": {
-                    "version": "5.2.0",
-                    "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
-                    "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
-                    "requires": {
-                        "@types/normalize-package-data": "^2.4.0",
-                        "normalize-package-data": "^2.5.0",
-                        "parse-json": "^5.0.0",
-                        "type-fest": "^0.6.0"
-                    },
-                    "dependencies": {
-                        "hosted-git-info": {
-                            "version": "2.8.9",
-                            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-                            "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
-                        },
-                        "normalize-package-data": {
-                            "version": "2.5.0",
-                            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-                            "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-                            "requires": {
-                                "hosted-git-info": "^2.1.4",
-                                "resolve": "^1.10.0",
-                                "semver": "2 || 3 || 4 || 5",
-                                "validate-npm-package-license": "^3.0.1"
-                            }
-                        },
-                        "semver": {
-                            "version": "5.7.1",
-                            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-                            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                        },
-                        "type-fest": {
-                            "version": "0.6.0",
-                            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-                            "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg=="
-                        }
-                    }
-                },
-                "read-pkg-up": {
-                    "version": "7.0.1",
-                    "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
-                    "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
-                    "requires": {
-                        "find-up": "^4.1.0",
-                        "read-pkg": "^5.2.0",
-                        "type-fest": "^0.8.1"
-                    },
-                    "dependencies": {
-                        "type-fest": {
-                            "version": "0.8.1",
-                            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-                            "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
-                        }
-                    }
-                },
-                "readable-stream": {
-                    "version": "3.6.0",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-                    "requires": {
-                        "inherits": "^2.0.3",
-                        "string_decoder": "^1.1.1",
-                        "util-deprecate": "^1.0.1"
-                    }
-                },
-                "receptacle": {
-                    "version": "1.3.2",
-                    "resolved": "https://registry.npmjs.org/receptacle/-/receptacle-1.3.2.tgz",
-                    "integrity": "sha512-HrsFvqZZheusncQRiEE7GatOAETrARKV/lnfYicIm8lbvp/JQOdADOfhjBd2DajvoszEyxSM6RlAAIZgEoeu/A==",
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
-                },
-                "redent": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
-                    "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
-                    "requires": {
-                        "indent-string": "^4.0.0",
-                        "strip-indent": "^3.0.0"
-                    }
-                },
-                "resolve": {
-                    "version": "1.20.0",
-                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-                    "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-                    "requires": {
-                        "is-core-module": "^2.2.0",
-                        "path-parse": "^1.0.6"
-                    }
-                },
-                "retimer": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/retimer/-/retimer-2.0.0.tgz",
-                    "integrity": "sha512-KLXY85WkEq2V2bKex/LOO1ViXVn2KGYe4PYysAdYdjmraYIUsVkXu8O4am+8+5UbaaGl1qho4aqAAPHNQ4GSbg=="
-                },
-                "retry": {
-                    "version": "0.13.1",
-                    "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-                    "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="
-                },
-                "safe-buffer": {
-                    "version": "5.2.1",
-                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-                    "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-                },
-                "safer-buffer": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-                    "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-                },
-                "semver": {
-                    "version": "7.3.5",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-                    "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-                    "requires": {
-                        "lru-cache": "^6.0.0"
-                    }
-                },
-                "sparse-array": {
-                    "version": "1.3.2",
-                    "resolved": "https://registry.npmjs.org/sparse-array/-/sparse-array-1.3.2.tgz",
-                    "integrity": "sha512-ZT711fePGn3+kQyLuv1fpd3rNSkNF8vd5Kv2D+qnOANeyKs3fx6bUMGWRPvgTTcYV64QMqZKZwcuaQSP3AZ0tg=="
-                },
-                "spdx-correct": {
-                    "version": "3.1.1",
-                    "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
-                    "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
-                    "requires": {
-                        "spdx-expression-parse": "^3.0.0",
-                        "spdx-license-ids": "^3.0.0"
-                    }
-                },
-                "spdx-exceptions": {
-                    "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
-                    "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A=="
-                },
-                "spdx-expression-parse": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
-                    "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
-                    "requires": {
-                        "spdx-exceptions": "^2.1.0",
-                        "spdx-license-ids": "^3.0.0"
-                    }
-                },
-                "spdx-license-ids": {
-                    "version": "3.0.9",
-                    "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.9.tgz",
-                    "integrity": "sha512-Ki212dKK4ogX+xDo4CtOZBVIwhsKBEfsEEcwmJfLQzirgc2jIWdzg40Unxz/HzEUqM1WFzVlQSMF9kZZ2HboLQ=="
-                },
-                "stream-to-it": {
-                    "version": "0.2.4",
-                    "resolved": "https://registry.npmjs.org/stream-to-it/-/stream-to-it-0.2.4.tgz",
-                    "integrity": "sha512-4vEbkSs83OahpmBybNJXlJd7d6/RxzkkSdT3I0mnGt79Xd2Kk+e1JqbvAvsQfCeKj3aKb0QIWkyK3/n0j506vQ==",
-                    "requires": {
-                        "get-iterator": "^1.0.2"
-                    }
-                },
-                "streaming-iterables": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/streaming-iterables/-/streaming-iterables-6.0.0.tgz",
-                    "integrity": "sha512-GYbJh0ife8PvryWSyFifY1m1uj6zO12d9duuP6xltiOolUz44eKasp5gbFhRbFbLy50ik6hcKn4Pbxl9AkxB+Q=="
-                },
-                "string.prototype.trimend": {
-                    "version": "1.0.4",
-                    "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
-                    "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
-                    "requires": {
-                        "call-bind": "^1.0.2",
-                        "define-properties": "^1.1.3"
-                    }
-                },
-                "string.prototype.trimstart": {
-                    "version": "1.0.4",
-                    "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
-                    "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
-                    "requires": {
-                        "call-bind": "^1.0.2",
-                        "define-properties": "^1.1.3"
-                    }
-                },
-                "string_decoder": {
-                    "version": "1.3.0",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-                    "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-                    "requires": {
-                        "safe-buffer": "~5.2.0"
-                    }
-                },
-                "strip-indent": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
-                    "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
-                    "requires": {
-                        "min-indent": "^1.0.0"
-                    }
-                },
-                "supports-color": {
-                    "version": "5.5.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-                    "requires": {
-                        "has-flag": "^3.0.0"
-                    }
-                },
-                "timeout-abort-controller": {
-                    "version": "1.1.1",
-                    "resolved": "https://registry.npmjs.org/timeout-abort-controller/-/timeout-abort-controller-1.1.1.tgz",
-                    "integrity": "sha512-BsF9i3NAJag6T0ZEjki9j654zoafI2X6ayuNd6Tp8+Ul6Tr5s4jo973qFeiWrRSweqvskC+AHDKUmIW4b7pdhQ==",
-                    "requires": {
-                        "abort-controller": "^3.0.0",
-                        "retimer": "^2.0.0"
-                    }
-                },
-                "trim-newlines": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
-                    "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw=="
-                },
-                "type-fest": {
-                    "version": "0.18.1",
-                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
-                    "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw=="
-                },
-                "uint8arrays": {
-                    "version": "2.1.7",
-                    "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-2.1.7.tgz",
-                    "integrity": "sha512-k+yuEWEHQG/TuRaxL+JVEe8IBqyU5dhDkw+CISCDccOcW90dIju0A6i0Iwav0MK7kg73FZpowqOByS5e/B6GYA==",
-                    "requires": {
-                        "multiformats": "^9.4.2"
-                    }
-                },
-                "unbox-primitive": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
-                    "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
-                    "requires": {
-                        "function-bind": "^1.1.1",
-                        "has-bigints": "^1.0.1",
-                        "has-symbols": "^1.0.2",
-                        "which-boxed-primitive": "^1.0.2"
-                    }
-                },
-                "util": {
-                    "version": "0.12.4",
-                    "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
-                    "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
-                    "requires": {
-                        "inherits": "^2.0.3",
-                        "is-arguments": "^1.0.4",
-                        "is-generator-function": "^1.0.7",
-                        "is-typed-array": "^1.1.3",
-                        "safe-buffer": "^5.1.2",
-                        "which-typed-array": "^1.1.2"
-                    }
-                },
-                "util-deprecate": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                    "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-                },
-                "validate-npm-package-license": {
-                    "version": "3.0.4",
-                    "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-                    "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-                    "requires": {
-                        "spdx-correct": "^3.0.0",
-                        "spdx-expression-parse": "^3.0.0"
-                    }
-                },
-                "varint": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
-                    "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="
-                },
-                "web-encoding": {
-                    "version": "1.1.5",
-                    "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.1.5.tgz",
-                    "integrity": "sha512-HYLeVCdJ0+lBYV2FvNZmv3HJ2Nt0QYXqZojk3d9FJOLkwnuhzM9tmamh8d7HPM8QqjKH8DeHkFTx+CFlWpZZDA==",
-                    "requires": {
-                        "@zxing/text-encoding": "0.9.0",
-                        "util": "^0.12.3"
-                    }
-                },
-                "web-streams-polyfill": {
-                    "version": "3.0.3",
-                    "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.0.3.tgz",
-                    "integrity": "sha512-d2H/t0eqRNM4w2WvmTdoeIvzAUSpK7JmATB8Nr2lb7nQ9BTIJVjbQ/TRFVEh2gUH1HwclPdoPtfMoFfetXaZnA=="
-                },
-                "which-boxed-primitive": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
-                    "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
-                    "requires": {
-                        "is-bigint": "^1.0.1",
-                        "is-boolean-object": "^1.1.0",
-                        "is-number-object": "^1.0.4",
-                        "is-string": "^1.0.5",
-                        "is-symbol": "^1.0.3"
-                    }
-                },
-                "which-typed-array": {
-                    "version": "1.1.4",
-                    "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.4.tgz",
-                    "integrity": "sha512-49E0SpUe90cjpoc7BOJwyPHRqSAd12c10Qm2amdEZrJPCY2NDxaW01zHITrem+rnETY3dwrbH3UUrUwagfCYDA==",
-                    "requires": {
-                        "available-typed-arrays": "^1.0.2",
-                        "call-bind": "^1.0.0",
-                        "es-abstract": "^1.18.0-next.1",
-                        "foreach": "^2.0.5",
-                        "function-bind": "^1.1.1",
-                        "has-symbols": "^1.0.1",
-                        "is-typed-array": "^1.1.3"
-                    }
-                },
-                "yallist": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-                    "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-                },
-                "yargs-parser": {
-                    "version": "20.2.9",
-                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-                    "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
-                }
             }
+        },
+        "which-boxed-primitive": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+            "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+            "requires": {
+                "is-bigint": "^1.0.1",
+                "is-boolean-object": "^1.1.0",
+                "is-number-object": "^1.0.4",
+                "is-string": "^1.0.5",
+                "is-symbol": "^1.0.3"
+            }
+        },
+        "which-typed-array": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.4.tgz",
+            "integrity": "sha512-49E0SpUe90cjpoc7BOJwyPHRqSAd12c10Qm2amdEZrJPCY2NDxaW01zHITrem+rnETY3dwrbH3UUrUwagfCYDA==",
+            "requires": {
+                "available-typed-arrays": "^1.0.2",
+                "call-bind": "^1.0.0",
+                "es-abstract": "^1.18.0-next.1",
+                "foreach": "^2.0.5",
+                "function-bind": "^1.1.1",
+                "has-symbols": "^1.0.1",
+                "is-typed-array": "^1.1.3"
+            }
+        },
+        "xtend": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+            "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+        },
+        "yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        },
+        "yargs-parser": {
+            "version": "20.2.9",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+            "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
         }
     }
 }

--- a/code-snippets/quickstart/package.json
+++ b/code-snippets/quickstart/package.json
@@ -9,7 +9,7 @@
     },
     "dependencies": {
         "minimist": "^1.2.5",
-        "web3.storage": "file://../../../web3.storage/packages/client"
+        "web3.storage": "^3.1.0"
     },
     "author": "YOUR NAME",
     "license": "(Apache-2.0 AND MIT)"


### PR DESCRIPTION
I noticed that the example package.json is requiring a pretty old version of the js client, so this bumps it up to the latest (3.1.0).