### PR TITLE
MERGE BLOCKED: update footer link

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -114,7 +114,7 @@ module.exports = {
           },
           nav:[
             { text: 'Status', link: `https://web3-storage.statuspage.io/` },
-            { text: 'Terms of service', link: `${MAIN_DOMAIN}/terms/` },
+            { text: 'Terms of service', link: `${MAIN_DOMAIN}/about/#terms-of-service` },
             { text: 'Open an issue', link: `/community/help-and-support/#bug-reports-or-feature-requests` },
             { text: 'Contact us', link: `/community/help-and-support` },
           ]


### PR DESCRIPTION
This WIP PR will edit our footer "Terms of service" link to direct to a header inside the /about page on the main site rather than to an /about page that's going away. (See ongoing thread about the changes [here in Slack](https://protocollabs.slack.com/archives/C02750576C8/p1627516681448400).) 

**DO NOT MERGE** until: 
- [x] legal team has completed their process
- [ ] Spark team has updated the About page with a header for the full terms of service (bottom part of page with multiple subheads included)
- [x] We've confirmed that the link included in the PR is indeed the right link to the top of the Terms of Service section there.  

@jnthnvctr @alanshaw @rafaelramalho19 @olizilla I know this is premature, but please flag us when the changes on your side are done so we can (correct if needed and) get this merged. This needs to be merged pretty immediatly after you make your changes so that we're not directing people to a Terms page that's not there. 