### PR TITLE
content: add list how-to guide

### DIFF
--- a/code-snippets/how-to/example-listing-upload.json
+++ b/code-snippets/how-to/example-listing-upload.json
@@ -11,7 +11,7 @@
   }],
   "deals": [{
     "dealId": 12345,
-    "miner": "f99",
+    "storageProvider": "f099",
     "status": "Active",
     "pieceCid": "bafkreifzjut3te2nhyekklss27nh3k72ysco7y32koao5eei66wof36n5e",
     "dataCid": "bafkreifzjut3te2nhyekklss27nh3k72ysco7y32koao5eei66wof36n5e",

--- a/code-snippets/how-to/example-listing-upload.json
+++ b/code-snippets/how-to/example-listing-upload.json
@@ -1,18 +1,23 @@
 {
-  "name": "Upload at 2021-07-29T19:53:47.663Z",
-  "cid": "bafybeiam6gyclz3a32y2m7u7rtp4roypuiyv42cbhgjayffgfbjfmnz5va",
-  "created": "2021-07-29T19:53:53.093461Z",
-  "dagSize": 3323885,
-  "pins": [
-    {
-      "status": "Pinned"
-    },
-    {
-      "status": "Pinned"
-    },
-    {
-      "status": "Pinned"
-    }
-  ],
-  "deals": []
+  "name": "cat pics",
+  "cid": "bafkreifzjut3te2nhyekklss27nh3k72ysco7y32koao5eei66wof36n5e",
+  "created": "2021-07-14T19:27:14.934572Z",
+  "dagSize": 101,
+  "pins": [{
+    "peerId": "12D3KooWR1Js",
+    "peerName": "peerName",
+    "region": "peerRegion",
+    "status": "Pinned"
+  }],
+  "deals": [{
+    "dealId": 12345,
+    "miner": "f99",
+    "status": "Active",
+    "pieceCid": "bafkreifzjut3te2nhyekklss27nh3k72ysco7y32koao5eei66wof36n5e",
+    "dataCid": "bafkreifzjut3te2nhyekklss27nh3k72ysco7y32koao5eei66wof36n5e",
+    "dataModelSelector": "Links/0/Links",
+    "activation": "2021-07-14T19:27:14.934572Z",
+    "created": "2021-07-14T19:27:14.934572Z",
+    "updated": "2021-07-14T19:27:14.934572Z"
+  }]
 }

--- a/code-snippets/how-to/example-listing-upload.json
+++ b/code-snippets/how-to/example-listing-upload.json
@@ -4,9 +4,6 @@
   "created": "2021-07-14T19:27:14.934572Z",
   "dagSize": 101,
   "pins": [{
-    "peerId": "12D3KooWR1Js",
-    "peerName": "peerName",
-    "region": "peerRegion",
     "status": "Pinned"
   }],
   "deals": [{

--- a/code-snippets/how-to/example-listing-upload.json
+++ b/code-snippets/how-to/example-listing-upload.json
@@ -1,0 +1,18 @@
+{
+  "name": "Upload at 2021-07-29T19:53:47.663Z",
+  "cid": "bafybeiam6gyclz3a32y2m7u7rtp4roypuiyv42cbhgjayffgfbjfmnz5va",
+  "created": "2021-07-29T19:53:53.093461Z",
+  "dagSize": 3323885,
+  "pins": [
+    {
+      "status": "Pinned"
+    },
+    {
+      "status": "Pinned"
+    },
+    {
+      "status": "Pinned"
+    }
+  ],
+  "deals": []
+}

--- a/code-snippets/how-to/index.js
+++ b/code-snippets/how-to/index.js
@@ -96,3 +96,33 @@ async function checkStatus(cid) {
 // replace with your own CID to see info about your uploads!
 checkStatus('bafybeifljln6rmvrdqu7xopiwk2bykwa25onxnvjsmlp3xdiii3opgg2gq')
 //#endregion query-status
+
+
+//#region listUploads
+async function listUploads() {
+  const client = makeStorageClient()
+  for await (const upload of client.list()) {
+    console.log(`${upload.name} - cid: ${upload.cid} - size: ${upload.dagSize}`)
+  }
+}
+//#endregion listUploads
+
+//#region listWithLimits
+async function listWithLimits() {
+  const client = makeStorageClient()
+
+  // get today's date and subtract 1 day
+  const d = new Date()
+  d.setDate(d.getDate() - 1)
+
+  // the list method's before parameter accepts an ISO formatted string
+  const before = d.toISOString()
+
+  // limit to ten results
+  const maxResults = 10
+
+  for await (const upload of client.list({ before, maxResults })) {
+    console.log(upload)
+  }
+}
+//#endregion listWithLimits

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -80,6 +80,7 @@ module.exports = {
               '/how-tos/store',
               '/how-tos/retrieve',
               '/how-tos/query',
+              '/how-tos/list',
               '/how-tos/generate-api-token'
             ]
           },

--- a/docs/how-tos/list.md
+++ b/docs/how-tos/list.md
@@ -46,8 +46,6 @@ Here's an example that logs details about each upload to the console:
 
 Each `Upload` object will look something like this:
 
-<!-- TODO: replace with example that includes deal status -->
-
 <<<@/code-snippets/how-to/example-listing-upload.json
 
 What do all those fields mean? Here's a summary:

--- a/docs/how-tos/list.md
+++ b/docs/how-tos/list.md
@@ -58,7 +58,7 @@ What do all those fields mean? Here's a summary:
 - `deals` contains an array of objects describing the Filecoin storage providers that have made [storage deals][fil-docs-deals]. These storage providers have committed to storing the data for an agreed period of time.
 
 ::: tip Want more details about storage?
-The `Upload` objects returned by the `list` method include some basic status information about how the data is stored on IPFS and Filecoin. For more details, including the identity of the storage providers hosting your data, you can [query an upload's status][howto-query] using the the `cid`.
+The `Upload` objects returned by the `list` method include some basic status information about how the data is stored on IPFS and Filecoin. For more details, including the identity of the storage providers hosting your data, you can [query an upload's status][howto-query] using the `cid`.
 :::
 
 #### Listing a subset of uploads

--- a/docs/how-tos/list.md
+++ b/docs/how-tos/list.md
@@ -38,7 +38,7 @@ You can use any API token associated with your account, not just the one you ori
 
 ### Listing your uploads
 
-The `Web3Storage` client object's `list` method returns an [async iterable][js-async-iterable-explainer] that can be used with the [`for await` syntax][mdn-for-await-of] to read information about each upload as soon as it's received over the network.
+The `Web3Storage` client object's [`list` method][reference-js-list] returns an [async iterable][js-async-iterable-explainer] that can be used with the [`for await` syntax][mdn-for-await-of] to read information about each upload as soon as it's received over the network.
 
 Here's an example that logs details about each upload to the console:
 
@@ -65,8 +65,8 @@ The `Upload` objects returned by the `list` method include some basic status inf
 
 #### Listing a subset of uploads
 
-By default. the `list` method returns information about all uploads made using your Web3.Storage account. You can optionally restrict the listing in two ways:
--  Only contain entries that were uploaded before a given timestamp.
+By default, the [`list` method][reference-js-list] returns information about all uploads made using your Web3.Storage account. You can optionally restrict the listing in two ways:
+- Only contain entries that were uploaded before a given timestamp.
 - Limit the total number of returned entries.
 
 Here's an example of fetching the first 10 uploads made on the previous day:
@@ -80,6 +80,7 @@ Here's an example of fetching the first 10 uploads made on the previous day:
 [concepts-decentralized-storage]: ../concepts/decentralized-storage.md
 [reference-js-client]: ../../reference/client-library.md
 [reference-js-constructor]: ../reference/client-library.md#constructor
+[reference-js-list]: ../reference/client-library.md#list-uploads
 [site-files]: https://web3.storage/files
 
 [ipfs-docs-gateway]: https://docs.ipfs.io/concepts/ipfs-gateway/

--- a/docs/how-tos/list.md
+++ b/docs/how-tos/list.md
@@ -6,7 +6,6 @@ description: Learn how to list the files you've uploaded to Web3.Storage in this
 # How to list files uploaded to Web3.Storage
 In this how-to guide, you'll learn about the different ways that you can **list the files that you've uploaded to Web3.Storage.**
 Once you've [stored some files][howto-store] using Web3.Storage, you'll want to see a list of what you've uplodaded. There are two ways you can do this:
-- Using the 
 
 ## Using the Web3.Storage website
 

--- a/docs/how-tos/list.md
+++ b/docs/how-tos/list.md
@@ -1,19 +1,24 @@
 ---
 title: List
-description: Learn how to list the files you've uploaded to Web3.Storage
+description: Learn how to list the files you've uploaded to Web3.Storage in this quick how-to guide.
 ---
 
 # How to list files uploaded to Web3.Storage
+In this how-to guide, you'll learn about the different ways that you can **list the files that you've uploaded to Web3.Storage.**
+Once you've [stored some files][howto-store] using Web3.Storage, you'll want to see a list of what you've uplodaded. There are two ways you can do this:
+- Using the 
 
-Once you've [stored some files][howto-store] using Web3.Storage, you can see a list of everything you've uploaded on the [Files page on the Web3.Storage website][site-files].
+## Using the Web3.Storage website
+
+You can see a list of everything you've uploaded to Web3.Storage on the [Files page][site-files] on the Web3.Storage website. If you don't need to work with this list programmatically, using the website may be a simpler choice.
 
 ![A screenshot of the file listing available at https://web3.storage/files when logged in to your account](../images/files-listing.png)
 
-The [Files page][site-files] provides a convenient overview of your stored data, with links to view your files using an [IPFS gateway][ipfs-docs-gateway] and information about how the data is being stored on the [decentralized storage networks][concepts-decentralized-storage] that Web3.Storage uses under the hood.
+This [Files page][site-files] provides a convenient overview of your stored data, including links to view your files in your browser via an [IPFS gateway][ipfs-docs-gateway] and information about how the data is being stored on the [decentralized storage networks][concepts-decentralized-storage] that Web3.Storage uses under the hood.
+## Using the Web3.Storage client
+To easily integrate Web3.Storage programmatically in your apps or services, you can also access a listing of your uploads from your code using the Web3.Storage client. In the example below, this guide walks through how to use the [JavaScript client library][reference-js-client] to fetch a complete listing of all the data you've uploaded using Web3.Storage.
 
-You can also access a listing of your uploads from your application code using the Web3.Storage client. This guide will show you how to use the [JavaScript client library][reference-js-client] to fetch a complete listing of all the data you've uploaded using Web3.Storage.
-
-## Installing the client
+### Installing the client
 
 In your JavaScript project, add the `web3.storage` package to your dependencies:
 
@@ -21,17 +26,17 @@ In your JavaScript project, add the `web3.storage` package to your dependencies:
 npm install web3.storage
 ```
 
-## Creating a client instance
+### Creating a client instance
 
 To create a `Web3Storage` client object, we need to pass an access token into the [constructor][reference-js-constructor]:
 
 <<<@/code-snippets/how-to/index.js#makeStorageClient
 
 :::tip
-You can use any access token associated with your account, not just the one you used to upload your files! See the [Generate API token page][howto-gen-token] for more about token management.
+You can use any API token associated with your account, not just the one you originally used to upload your files! See the [Generate API token page][howto-gen-token] for more about token management.
 :::
 
-## Listing your uploads
+### Listing your uploads
 
 The `Web3Storage` client object's `list` method returns an [async iterable][js-async-iterable-explainer] that can be used with the [`for await` syntax][mdn-for-await-of] to read information about each upload as soon as it's received over the network.
 
@@ -54,15 +59,17 @@ What do all those fields mean? Here's a summary:
 - `pins` contains an array of objects describing the IPFS nodes that have [pinned][ipfs-docs-pinning] the data, making it available for fast retrieval using the IPFS network.
 - `deals` contains an array of objects describing the Filecoin storage providers that have made [storage deals][fil-docs-deals]. These storage providers have committed to storing the data for an agreed period of time.
 
-::: tip "Want more details about storage?"
+::: tip Want more details about storage?
 The `Upload` objects returned by the `list` method include some basic status information about how the data is stored on IPFS and Filecoin. For more details, including the identity of the storage providers hosting your data, you can [query an upload's status][howto-query] using the the `cid`.
 :::
 
-### Listing a subset of uploads
+#### Listing a subset of uploads
 
-By default the `list` method returns information about all uploads made using your Web3.Storage account. You can optionally restrict the listing to contain entries that were uploaded before a given timestamp, and you can also limit the total number of returned entries.
+By default. the `list` method returns information about all uploads made using your Web3.Storage account. You can optionally restrict the listing in two ways:
+-  Only contain entries that were uploaded before a given timestamp.
+- Limit the total number of returned entries.
 
-Here's an example of fetching the first ten uploads made on the previous day:
+Here's an example of fetching the first 10 uploads made on the previous day:
 
 <<<@/code-snippets/how-to/index.js#listWithLimits
 
@@ -72,7 +79,7 @@ Here's an example of fetching the first ten uploads made on the previous day:
 [howto-gen-token]: ./generate-api-token.md
 [concepts-decentralized-storage]: ../concepts/decentralized-storage.md
 [reference-js-client]: ../../reference/client-library.md
-
+[reference-js-constructor]: ../reference/client-library.md#constructor
 [site-files]: https://web3.storage/files
 
 [ipfs-docs-gateway]: https://docs.ipfs.io/concepts/ipfs-gateway/

--- a/docs/how-tos/list.md
+++ b/docs/how-tos/list.md
@@ -1,0 +1,86 @@
+---
+title: List
+description: Learn how to list the files you've uploaded to Web3.Storage
+---
+
+# How to list files uploaded to Web3.Storage
+
+Once you've [stored some files][howto-store] using Web3.Storage, you can see a list of everything you've uploaded on the [Files page on the Web3.Storage website][site-files].
+
+![A screenshot of the file listing available at https://web3.storage/files when logged in to your account](../images/files-listing.png)
+
+The [Files page][site-files] provides a convenient overview of your stored data, with links to view your files using an [IPFS gateway][ipfs-docs-gateway] and information about how the data is being stored on the [decentralized storage networks][concepts-decentralized-storage] that Web3.Storage uses under the hood.
+
+You can also access a listing of your uploads from your application code using the Web3.Storage client. This guide will show you how to use the [JavaScript client library][reference-js-client] to fetch a complete listing of all the data you've uploaded using Web3.Storage.
+
+## Installing the client
+
+In your JavaScript project, add the `web3.storage` package to your dependencies:
+
+```shell
+npm install web3.storage
+```
+
+## Creating a client instance
+
+To create a `Web3Storage` client object, we need to pass an access token into the [constructor][reference-js-constructor]:
+
+<<<@/code-snippets/how-to/index.js#makeStorageClient
+
+:::tip
+You can use any access token associated with your account, not just the one you used to upload your files! See the [Generate API token page][howto-gen-token] for more about token management.
+:::
+
+## Listing your uploads
+
+The `Web3Storage` client object's `list` method returns an [async iterable][js-async-iterable-explainer] that can be used with the [`for await` syntax][mdn-for-await-of] to read information about each upload as soon as it's received over the network.
+
+Here's an example that logs details about each upload to the console:
+
+<<<@/code-snippets/how-to/index.js#listUploads
+
+Each `Upload` object will look something like this:
+
+<!-- TODO: replace with example that includes deal status -->
+
+<<<@/code-snippets/how-to/example-listing-upload.json
+
+What do all those fields mean? Here's a summary:
+
+- `name` contains a descriptive name for the upload. If no name was provided at the time of upload, the `name` field will contain an automatically generated name that includes a creation timestamp.
+- `cid` contains the [IPFS Content Identifier (CID)][ipfs-docs-cid] that identifies the uploaded data. This CID can be used to [retrieve][howto-retrieve] the uploaded files or get more detailed [status information][howto-query].
+- `created` contains an [ISO-8601 datetime string][iso-8601] indicating when the content was first uploaded to Web3.Storage.
+- `dagSize` contains the size in bytes of the [Directed Acyclic Graph (DAG)][ipfs-docs-merkle-dag] that contains all the uploaded content. This is the size of the data that is transferred over the network to Web3.Storage during upload, and is slightly larger than the total size of the files on disk.
+- `pins` contains an array of objects describing the IPFS nodes that have [pinned][ipfs-docs-pinning] the data, making it available for fast retrieval using the IPFS network.
+- `deals` contains an array of objects describing the Filecoin storage providers that have made [storage deals][fil-docs-deals]. These storage providers have committed to storing the data for an agreed period of time.
+
+::: tip "Want more details about storage?"
+The `Upload` objects returned by the `list` method include some basic status information about how the data is stored on IPFS and Filecoin. For more details, including the identity of the storage providers hosting your data, you can [query an upload's status][howto-query] using the the `cid`.
+:::
+
+### Listing a subset of uploads
+
+By default the `list` method returns information about all uploads made using your Web3.Storage account. You can optionally restrict the listing to contain entries that were uploaded before a given timestamp, and you can also limit the total number of returned entries.
+
+Here's an example of fetching the first ten uploads made on the previous day:
+
+<<<@/code-snippets/how-to/index.js#listWithLimits
+
+[howto-store]: ./store.md
+[howto-retrieve]: ./retrive.md
+[howto-query]: ./query.md
+[howto-gen-token]: ./generate-api-token.md
+[concepts-decentralized-storage]: ../concepts/decentralized-storage.md
+[reference-js-client]: ../../reference/client-library.md
+
+[site-files]: https://web3.storage/files
+
+[ipfs-docs-gateway]: https://docs.ipfs.io/concepts/ipfs-gateway/
+[ipfs-docs-cid]: https://docs.ipfs.io/concepts/content-addressing/
+[ipfs-docs-merkle-dag]: https://docs.ipfs.io/concepts/merkle-dag/
+[ipfs-docs-pinning]: https://docs.ipfs.io/concepts/persistence/
+[fil-docs-deals]: https://docs.filecoin.io/about-filecoin/how-filecoin-works/#deals
+
+[iso-8601]: https://en.wikipedia.org/wiki/ISO_8601
+[js-async-iterable-explainer]: https://javascript.info/async-iterators-generators
+[mdn-for-await-of]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of


### PR DESCRIPTION
This add a how-to guide for listing your uploads using the JS client, with a mention that you can just view things on the files page as well.

closes #112 