### PR TITLE
refactor: quickstart put-files.js

### DIFF
--- a/code-snippets/quickstart/put-files.js
+++ b/code-snippets/quickstart/put-files.js
@@ -3,26 +3,28 @@ import minimist from 'minimist'
 import { Web3Storage, getFilesFromPath } from 'web3.storage'
 
 async function main () {
-    const args = minimist(process.argv.slice(2))
-    const token = args.token
+  const args = minimist(process.argv.slice(2))
+  const token = args.token
 
-    if (!token) {
-        console.error('A token is needed. You can create one on https://web3.storage')
-            return
-    }
+  if (!token) {
+    return console.error('A token is needed. You can create one on https://web3.storage')
+  }
 
-    if (args._.length < 1) {
-      console.error('Please supply the path to a file or directory')
-    }
+  if (args._.length < 1) {
+    return console.error('Please supply the path to a file or directory')
+  }
 
-    const storage = new Web3Storage({ token })
+  const storage = new Web3Storage({ token })
+  const files = []
 
-    for (const path of args._) {
-      const files = await getFilesFromPath(path)
-      console.log(`Uploading files from ${path}`)
-      const cid = await storage.put(files)
-      console.log('Content added with CID:', cid)
-    }
+  for (const path of args._) {
+    const pathFiles = await getFilesFromPath(path)
+    files.push(...pathFiles)
+  }
+
+  console.log(`Uploading ${files.length} files`)
+  const cid = await storage.put(files)
+  console.log('Content added with CID:', cid)
 }
 
 main()


### PR DESCRIPTION
This PR refactors put files to do the following things:

1. Collect _all_ the files from _all_ the given paths and _then_ upload them all into the same directory, rather than getting a CID per path.
2. Return on failure when there are no files (I know technically we didn't need to do this _before_, but leaving it to fall through makes it brittle to changes and we actually _need_ to do this now to prevent an error being thrown)
3. Consistently use 2 spaces for indentation. The current file is a mixture of 2 and 4 spaces. The JS community traditionally use 2 spaces so that's what I went with here. Sorry for the noise.

I don't know if (1) was the original intention or not, but I've just had a user asking about why the files don't all get put in one directory. I _think_ this is what I'd expect this example to do also. There is a work around though - put the files in a directory `mydir` and then run `node put-files ./mydir`.

⚠️ I didn't actually run this so please run it to check it works ok before merging!