### PR TITLE
quickstart: callout that you can add multiple files / directories

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -139,6 +139,10 @@ Now that you've got your script ready to go, you just need to run it in your ter
     node put-files.js --token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJkaWQ6ZXRocjoweGZFYTRhODlFNUVhRjY5YWI4QUZlZUU3MUE5OTgwQjFGQ2REZGQzNzIiLCJpc3MiOiJ3ZWIzLXN0b3JhZ2UiLCJpYXQiOjE2MjY5Njk3OTY1NTQsIm5hbWUiOiJib25maXJlIn0.0S9Ua2FWEAZSwaemy92N7bW8ancRUtu4XtLS3Gy1ouA ~/hello.txt
     ```
 
+    ::: tip Multiple files
+    You can upload a whole directory full of files at once by giving the script the path to a local directory. You can also upload multiple files by passing in more than one file path when you run the script.
+    :::
+
 1. The command will output a CID:
 
     ```shell output


### PR DESCRIPTION
This adds a tip box to the quickstart to explain that you can upload a directory or pass in multiple files to the example script. 

@atopal it sounds like a few people wanted to see an example of uploading a bunch of files at once (e.g. #124). 

I didn't add a full code example since the rest of the text talks about "your file" in the singular. Do you think this callout is enough?