### PR TITLE
Style: Banner at bottom on short pages

### DIFF
--- a/docs/.vuepress/theme/components/Page.vue
+++ b/docs/.vuepress/theme/components/Page.vue
@@ -68,6 +68,7 @@ export default {
 
   top: 3.6rem;
   margin-top: calc(-1 * (100vh - 2.5rem));
+  min-height: calc(100vh - 2.5rem);
 }
 
 .content-footer {

--- a/docs/.vuepress/theme/layouts/GlobalLayout.vue
+++ b/docs/.vuepress/theme/layouts/GlobalLayout.vue
@@ -90,7 +90,7 @@ export default {
 #global-layout {
   display: flex;
   flex-direction: column;
-  min-height: 100%;
+  min-height: 104%;
 }
 
 .banner--nft-storage {


### PR DESCRIPTION
This PR slightly increases min-height of `#global-layout` so the footer nav doesn't run short of the bottom of the page on low-content pages.

This had originally been fixed in https://github.com/web3-storage/docs/pull/19/files but I believe that adding the NFT Storage banner re-introduced the problem. @terichadbourne - can you think of a more elegant solution than this one? It feels a bit hacky, but it works.

Closes https://github.com/web3-storage/docs/issues/129.