### PR TITLE
Add dag-cbor examples with IPLD links

### DIFF
--- a/code-snippets/how-to/dag-cbor.js
+++ b/code-snippets/how-to/dag-cbor.js
@@ -1,29 +1,131 @@
+//#region imports
 import { Web3Storage } from 'web3.storage'
 import { CarReader, CarWriter } from '@ipld/car'
 import { encode } from 'multiformats/block'
 import * as cbor from '@ipld/dag-cbor'
 import { sha256 } from 'multiformats/hashes/sha2'
+//#endregion imports
 
-async function storeDagCBOR(value) {
-  // encode the value into an IPLD block, using the cbor codec and sha256 hash function
-  const block = await encode({ value, codec: cbor, hasher: sha256 })
+//#region encodeCborBlock
+async function encodeCborBlock(value) {
+  return encode({ value, codec: cbor, hasher: sha256 })
+}
+//#endregion encodeCborBlock
 
-  // create a new CarWriter, with the encoded block as the root
-  const { writer, out } = CarWriter.create([block.cid])
+//#region makeCar
+async function makeCar(rootCID, ipldBlocks) {
+  // create a new CarWriter, with the given root CID
+  const { writer, out } = CarWriter.create([rootCID])
 
-  // add the block to the CAR and close it
-  writer.put(block)
+  // add the blocks to the CAR and close it
+  for (const block of ipldBlocks) {
+    writer.put(block)
+  }
   writer.close()
 
   // create a new CarReader we can hand to Web3.Storage.putCar
   const reader = await CarReader.fromIterable(out)
+  return reader
+}
+//#endregion makeCar
+
+//#region simpleCborExample
+async function simpleCborExample() {
+  // encode the value into an IPLD block and store with Web3.Storage
+  const block = await encodeCborBlock({ hello: 'world' })
+  const car = await makeCar(block.cid, [block])
 
   // upload to Web3.Storage using putCar
   const client = new Web3Storage({ token: process.env.WEB3STORAGE_TOKEN })
-  const cid = await client.putCar(reader)
-  console.log('stored dag-cbor data! CID:', cid)
+  console.log(`🤖 Storing simple CBOR object...`)
+  const cid = await client.putCar(car)
+  console.log(`🎉 Done storing simple CBOR object. CID: ${cid}`)
+  console.log(`💡 If you have ipfs installed, try: ipfs dag get ${cid}\n`)
 }
+//#endregion simpleCborExample
 
-storeDagCBOR({
-  hello: 'world'
-})
+//#region cborLinkExample
+async function cborLinkExample() {
+  // Encode a simple object to get its CID
+  const addressBlock = await encodeCborBlock({ email: 'zaphod@beeblebrox.galaxy' })
+
+  // Now we can use the CID to link to the object from another object
+  const personBlock = await encodeCborBlock({
+    title: 'Galactic President',
+    description: 'Just this guy, you know?',
+    contact: addressBlock.cid,
+  })
+
+  // pack everything into a CAR
+  const car = await makeCar(personBlock.cid, [personBlock, addressBlock])
+
+  // upload to Web3.Storage using putCar
+  const client = new Web3Storage({ token: process.env.WEB3STORAGE_TOKEN })
+
+  console.log(`🤖 Storing CBOR objects with CID links between them...`)
+  const cid = await client.putCar(car)
+  console.log('🎉 Stored linked data using dag-cbor. Root CID:', cid)
+  console.log(`💡 If you have ipfs installed, try: ipfs dag get ${cid}`)
+  console.log(`🔗 You can also traverse the link by path: ipfs dag get ${cid}/contact\n`)
+}
+//#endregion cborLinkExample
+
+//#region makeUnixFsFile
+import { importer } from 'ipfs-unixfs-importer'
+import { MemoryBlockStore } from 'ipfs-car/blockstore/memory'
+async function makeUnixFsFile(source) {
+  const blockstore = new MemoryBlockStore()
+  // taken from https://github.com/web3-storage/ipfs-car/blob/main/src/pack/constants.ts
+  // but with wrapWithDirectory overriden to false
+  const unixFsOptions = {
+    cidVersion: 1,
+    chunker: 'fixed',
+    maxChunkSize: 262144,
+    hasher: sha256,
+    rawLeaves: true,
+    wrapWithDirectory: false,
+    maxChildrenPerNode: 174
+  }
+  const importStream = await importer(source, blockstore, unixFsOptions)
+  let root = null
+  for await (const entry of importStream) {
+    root = entry
+  }
+  const blocks = []
+  for await (const block of blockstore.blocks()) {
+    blocks.push(block)
+  }
+  await blockstore.close()
+  return { root, blocks }
+}
+//#endregion makeUnixFsFile
+
+//#region cborLinkToFileExample
+async function cborLinkToFileExample() {
+  const source = [{
+    path: 'example.txt',
+    content: new TextEncoder().encode('Some plain text, encoded to UTF-8')
+  }] 
+  const { root, blocks }  = await makeUnixFsFile(source)
+  const cborBlock = await encodeCborBlock({
+    description: 'A CBOR object that references a UnixFS file object by CID',
+    file: root.cid,
+  })
+
+  blocks.push(cborBlock)
+  const car = await makeCar(cborBlock.cid, blocks)
+
+  const client = new Web3Storage({ token: process.env.WEB3STORAGE_TOKEN })
+  console.log(`🤖 Storing a CBOR object that links to a UnixFS file by CID...`)
+  const cid = await client.putCar(car)
+  console.log('🎉 Stored dag-cbor object that links to a unixfs file. Root CID: ', cid)
+  console.log(`💡 If you have ipfs installed, try: ipfs dag get ${cid}`)
+  console.log(`💾 You can view the linked file with ipfs: ipfs cat ${cid}/file`)
+  console.log('🔗 View linked file via IPFS gateway: ', `https://${cid}.ipfs.dweb.link/file`)
+}
+//#endregion cborLinkToFileExample
+
+simpleCborExample()
+  .then(cborLinkExample)
+  .then(cborLinkToFileExample)
+  .catch(console.error)

--- a/code-snippets/how-to/package-lock.json
+++ b/code-snippets/how-to/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@ipld/dag-json": "^8.0.0",
+        "ipfs-unixfs-importer": "^8.0.1",
         "web3.storage": "^3.3.0"
       }
     },

--- a/code-snippets/how-to/package.json
+++ b/code-snippets/how-to/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "type": "module",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/web3-storage/docs.git"
@@ -18,6 +19,7 @@
   "homepage": "https://github.com/web3-storage/docs#readme",
   "dependencies": {
     "@ipld/dag-json": "^8.0.0",
+    "ipfs-unixfs-importer": "^8.0.1",
     "web3.storage": "^3.3.0"
   }
 }

--- a/docs/how-tos/work-with-car-files.md
+++ b/docs/how-tos/work-with-car-files.md
@@ -162,9 +162,148 @@ The `image` field uses the special "link type" to reference another IPLD object.
 
 Although `dag-json` is familiar and easy to use, we recommend using the similar [`dag-cbor` codec](https://ipld.io/docs/codecs/known/dag-cbor/) instead. `dag-cbor` uses the [Concise Binary Object Representation](https://cbor.io) to more efficiently encode data, especially binary data which must be Base64-encoded when using `dag-json`.
 
-Here's a small example of encoding some `dag-cbor` data into a CAR that can be uploaded to Web3.Storage:
+### Examples
 
-<<<@/code-snippets/how-to/dag-cbor.js
+Below are some examples of working with `dag-cbor` data and sending it to Web3.Storage.
+
+First, you'll need to import some things:
+
+<<<@/code-snippets/how-to/dag-cbor.js#imports
+
+Now we'll define a convenience function to encode an IPLD block of CBOR data and hash with SHA2-256:
+
+::: details encodeCborBlock(value)
+<<<@/code-snippets/how-to/dag-cbor.js#encodeCborBlock
+:::
+
+And a function to make a CAR from a collection of blocks and a root CID:
+
+::: details makeCar(rootCID, ipldBlocks)
+<<<@/code-snippets/how-to/dag-cbor.js#makeCar
+:::
+
+#### Storing simple CBOR data
+
+Using the helpers above, you can make a CAR file with a single block of simple CBOR data and send it to Web3.Storage:
+
+::: details simpleCborExample()
+<<<@/code-snippets/how-to/dag-cbor.js#simpleCborExample
+:::
+
+If you have the IPFS command line app installed, you can view the object you stored with the [`ipfs dag get` command][ipfs-docs-dag-get], for example:
+
+```shell with-output
+ipfs dag get bafyreidykglsfhoixmivffc5uwhcgshx4j465xwqntbmu43nb2dzqwfvae
+```
+
+```json
+{
+  "hello": "world"
+}
+```
+
+Note that the example output has been indented with [jq](https://stedolan.github.io/jq/) for clarity.The real command will output a compact `dag-json` representation of the CBOR data without any extra whitespace.
+
+#### CBOR with IPLD links
+
+You can link from one CBOR object to another using CIDs:
+
+::: details cborLinkExample()
+<<<@/code-snippets/how-to/dag-cbor.js#cborLinkExample
+:::
+
+As with simple objects, you can use `ipfs dag get` to show the outer object:
+
+```shell with-output
+ipfs dag get bafyreieq6bftbe3o46lrdbzj6vrvyee4njfschajxgmpxwbqex3czifhry
+```
+
+```json
+{
+  "contact": {
+    "/": "bafyreicp2g6ez5exmw5uxsns7kkwtxr5z4vyx4xkdci6xpy2vou3zqc6me"
+  },
+  "description": "Just this guy, you know?",
+  "title": "Galactic President"
+}
+```
+
+The `contact` field above contains an IPLD link, which can be included in the `ipfs dag get` command to resolve the linked object:
+
+```shell with-output
+ipfs dag get bafyreieq6bftbe3o46lrdbzj6vrvyee4njfschajxgmpxwbqex3czifhry/contact
+```
+
+```json
+{"email":"zaphod@beeblebrox.galaxy"}
+```
+
+#### Linking from CBOR to an IPFS file
+
+Our final example is a little more complex. We're going to store a file in the same UnixFS format that IPFS uses, and link to it from a CBOR object.
+
+First we'll encode a file into UnixFS format. Normally this is done by the client library, but we want to get the CID of the file object to use for our link before we send the file off to Web3.Storage, so we'll construct the UnixFS object ourselves.
+
+Here's a helper function to make a UnixFS file and encode it to an IPLD block:
+
+::: details makeUnixFsFile(source)
+<<<@/code-snippets/how-to/dag-cbor.js#makeUnixFsFile
+:::
+
+The helper returns a `root` block, which we can link to by CID, as well as a `blocks` array containing the encoded file data. When we create the CAR to send to Web3.Storage, it's important to include all the file blocks as well as the CBOR block.
+
+::: details cborLinkToFileExample()
+<<<@/code-snippets/how-to/dag-cbor.js#cborLinkToFileExample
+:::
+
+As before, we can view the root block with `ipfs dag get`:
+
+```shell with-output
+ipfs dag get bafyreid7hvce4pzcy56s4hwu7xrt3dnnzzfvilzfwsadvf6q4eqild6ndy
+```
+
+```json
+{
+  "description": "A CBOR object that references a UnixFS file object by CID",
+  "file": {
+    "/": "bafkreihmlglmfpadbk4fy72ljniveedbqicysoe5zhqqkgkuso3e6xyns4"
+  }
+}
+```
+
+Since the file data is plain text, you can use `ipfs dag get` to fetch its contents:
+
+```shell with-output
+ipfs dag get bafyreid7hvce4pzcy56s4hwu7xrt3dnnzzfvilzfwsadvf6q4eqild6ndy/file
+```
+
+```json
+"Some plain text, encoded to UTF-8"
+```
+
+Notice that the file content is wrapped in quotes, because `dag get` is interpreting the content as a JSON string.
+
+To avoid this, or to fetch binary files, you can use `ipfs get` to download the file:
+
+```shell with-output
+ipfs get bafyreid7hvce4pzcy56s4hwu7xrt3dnnzzfvilzfwsadvf6q4eqild6ndy/file
+```
+
+```text
+Saving file(s) to file
+ 33 B / 33 B [===============================================================] 100.00% 0s
+```
+
+
+Note that the IPFS HTTP gateway currently does not support rendering CBOR data, so the root object is not directly viewable via the gateway. See the note about gateway support below for more information.
+
+However, the gateway *is* able to traverse the IPLD links inside our CBOR object, so you can link to the file by path and the gateway will resolve the linked file. For example:
+
+[https://bafyreid7hvce4pzcy56s4hwu7xrt3dnnzzfvilzfwsadvf6q4eqild6ndy.ipfs.dweb.link/file](https://bafyreid7hvce4pzcy56s4hwu7xrt3dnnzzfvilzfwsadvf6q4eqild6ndy.ipfs.dweb.link/file).
+
+::: warning Gateway support
+Although Web3.Storage supports storing CAR files with `dag-cbor` content by default and can accept other codecs with the `decoders` option, the IPFS HTTP gateway does not currently "speak" these formats and is not able to provide such data over HTTP. Please follow [this issue](https://github.com/ipfs/go-ipfs/issues/8234) to track the development of this feature.
+:::
 
 ### Enabling IPLD codecs in the client library
 
@@ -172,9 +311,6 @@ By default, the client's [`putCar` method][reference-client-putCar] will accept 
 
 See the [`putCar` parameter reference][reference-client-putCar-params] for more details and an example that uses `dag-json`.
 
-::: warning Gateway support
-Although Web3.Storage supports storing CAR files with `dag-cbor` content by default and can accept other codecs with the `decoders` option, the IPFS HTTP gateway does not currently "speak" these formats and is not able to provide such data over HTTP. Please follow [this issue](https://github.com/ipfs/go-ipfs/issues/8234) to track the development of this feature.
-:::
 
 [concepts-content-addressing]: ../concepts/content-addressing.md
 [reference-client-library]: ../reference/client-library.md
@@ -185,5 +321,6 @@ Although Web3.Storage supports storing CAR files with `dag-cbor` content by defa
 [github-ipfs-car]: https://github.com/web3-storage/ipfs-car
 [ipfs-docs-dag-export]: https://docs.ipfs.io/reference/cli/#ipfs-dag-export
 [ipfs-docs-dag-import]: https://docs.ipfs.io/reference/cli/#ipfs-dag-import
+[ipfs-docs-dag-get]: https://docs.ipfs.io/reference/cli/#ipfs-dag-get
 [car-spec]: https://ipld.io/specs/transport/car/
 [wikipedia-tar]: https://en.wikipedia.org/wiki/Tar_(computing)

--- a/docs/how-tos/work-with-car-files.md
+++ b/docs/how-tos/work-with-car-files.md
@@ -242,7 +242,7 @@ ipfs dag get bafyreieq6bftbe3o46lrdbzj6vrvyee4njfschajxgmpxwbqex3czifhry/contact
 
 Our final example is a little more complex. We're going to store a file in the same UnixFS format that IPFS uses, and link to it from a CBOR object.
 
-First we'll encode a file into UnixFS format. Normally this is done by the client library, but we want to get the CID of the file object to use for our link before we send the file off to Web3.Storage, so we'll construct the UnixFS object ourselves.
+First, we'll encode a file into UnixFS format. Normally, this is done by the client library, but we want to get the CID of the file object to use for our link before we send the file off to Web3.Storage, so we'll construct the UnixFS object ourselves.
 
 Here's a helper function to make a UnixFS file and encode it to an IPLD block:
 
@@ -281,7 +281,7 @@ ipfs dag get bafyreid7hvce4pzcy56s4hwu7xrt3dnnzzfvilzfwsadvf6q4eqild6ndy/file
 "Some plain text, encoded to UTF-8"
 ```
 
-Notice that the file content is wrapped in quotes, because `dag get` is interpreting the content as a JSON string.
+Notice that the file content is wrapped in quotes because `dag get` is interpreting the content as a JSON string.
 
 To avoid this, or to fetch binary files, you can use `ipfs get` to download the file:
 
@@ -297,12 +297,12 @@ Saving file(s) to file
 
 Note that the IPFS HTTP gateway currently does not support rendering CBOR data, so the root object is not directly viewable via the gateway. See the note about gateway support below for more information.
 
-However, the gateway *is* able to traverse the IPLD links inside our CBOR object, so you can link to the file by path and the gateway will resolve the linked file. For example:
+However, the gateway *can* traverse the IPLD links inside our CBOR object, so you can link to the file by path and the gateway will resolve the linked file. For example:
 
 [https://bafyreid7hvce4pzcy56s4hwu7xrt3dnnzzfvilzfwsadvf6q4eqild6ndy.ipfs.dweb.link/file](https://bafyreid7hvce4pzcy56s4hwu7xrt3dnnzzfvilzfwsadvf6q4eqild6ndy.ipfs.dweb.link/file).
 
 ::: warning Gateway support
-Although Web3.Storage supports storing CAR files with `dag-cbor` content by default and can accept other codecs with the `decoders` option, the IPFS HTTP gateway does not currently "speak" these formats and is not able to provide such data over HTTP. Please follow [this issue](https://github.com/ipfs/go-ipfs/issues/8234) to track the development of this feature.
+Although Web3.Storage supports storing CAR files with `dag-cbor` content by default and can accept other codecs with the `decoders` option, the IPFS HTTP gateway does not currently "speak" these formats and will not return such data over HTTP. Please follow [this issue](https://github.com/ipfs/go-ipfs/issues/8234) to track the development of this feature.
 :::
 
 ### Enabling IPLD codecs in the client library


### PR DESCRIPTION
@alanshaw inspired me to add some more interesting examples of using `dag-cbor` in the "working with CARs" guide.

This adds an example of linking from CBOR to CBOR, and from CBOR to UnixFS. 

Everything seems to work... I added `"type": "module"` to the package.json for the example code, so it's easier to try it out now. Just `cd code-snippets/how-tos && node dag-cbor.js`.

Oddly none of the cbor CIDs I put will resolve in the [IPLD explorer](https://explore.ipld.io). E.g. if I paste in `bafyreid7hvce4pzcy56s4hwu7xrt3dnnzzfvilzfwsadvf6q4eqild6ndy` it just spins forever. The gateway is able to traverse to the linked file though: https://bafyreid7hvce4pzcy56s4hwu7xrt3dnnzzfvilzfwsadvf6q4eqild6ndy.ipfs.dweb.link/file

