### PR TITLE
add delete operation to openapi schema

### DIFF
--- a/docs/.vuepress/public/schema.yml
+++ b/docs/.vuepress/public/schema.yml
@@ -197,7 +197,48 @@ paths:
           $ref: '#/components/responses/forbidden'
         '5XX':
           $ref: '#/components/responses/internalServerError'
+  /user/uploads/{cid}:
+    delete:
+      tags:
+        - Web3.Storage HTTP API
+      summary: Remove uploaded content from your account
+      description: |
+        Removes the content identified by `cid` from your Web3.Storage account. 
+        This will remove the entry for the upload from your file listing page and the upload listing API. 
+        It will also reduce the storage usage associated with your account by the size of the removed content.
 
+        __⚠️ This does not remove the content from the network. ⚠️__
+
+        Removing an upload from your account does not remove content from the distributed storage networks used by Web3.Storage. 
+        
+        - Removal does not terminate any established Filecoin deal.
+        - Removing an upload does not remove the content from other IPFS nodes in the network that have already cached or pinned the CID.
+
+        Note that the content will also remain available if another user has stored the CID with Web3.Storage. 
+        If no other users have uploaded the removed CID, the Web3.Storage service _may_ do the following at any time:
+        - Unpin the content from IPFS clusters and pinning services used by Web3.Storage.
+        - Cease renewals for expired Filecoin deals involving the CID.
+
+      operationId: delete
+      parameters:
+        - name: cid
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/CID'
+      responses:
+        '200':
+          description: OK
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/DeleteResponse'
+        '401':
+          $ref: '#/components/responses/unauthorized'
+        '403':
+          $ref: '#/components/responses/forbidden'
+        '5XX':
+          $ref: '#/components/responses/internalServerError'
 
 
 
@@ -308,6 +349,11 @@ components:
       properties:
         cid:
           $ref: '#/components/schemas/CID'
+    DeleteResponse:
+      type: object
+      properties:
+        ok:
+          type: boolean
     ErrorResponse:
       type: object
       properties:


### PR DESCRIPTION
This adds `DELETE /user/uploads/{cid}` to the HTTP API docs, to close https://github.com/web3-storage/web3.storage/issues/376

I _think_ that the OpenAPI spec in this repo is the latest "source of truth", but there's also a draft spec in https://github.com/web3-storage/web3.storage/pull/145, which is where I pulled the definition from. Unfortunately I didn't sync about this with John or Alan before they went OOO, so I'm not certain what the status of the draft spec is.

It seems like the spec ideally belongs in the main web3.storage repo, so perhaps its better to add things over there going forward? We could have a script in this repo that pulls in the latest spec before building the docs site, until we smoosh the two sites together someday.

@dchoi27 do you have any thoughts on putting the schema in the main repo and pulling it in here with a script?