### PR TITLE
explain how to control filename of gateway downloads

### DIFF
--- a/docs/how-tos/retrieve.md
+++ b/docs/how-tos/retrieve.md
@@ -29,6 +29,29 @@ If you want to link directly to a file within that directory, just add the file 
 Your [Files page](https://web3.storage/files/) on Web3.Storage includes IPFS gateway links to all the content you've uploaded, so if you're looking to link to one of your own files, you don't even have to create a gateway URL.
 :::
 
+### Setting the filename for downloads via gateways
+
+When downloading files from an HTTP gateway, web browsers will set the default filename for the downloaded file based on the path component of the gateway link. For example, if you use your browser's "Save link as..." feature on the following link, it should prompt you to save a file named `treehouse.jpeg`:
+
+[https://bafybeicfnbaeigdtklwkrj35r4wtfppix732zromsadvgiu33mowah74yq.ipfs.dweb.link/treehouse.jpeg](https://bafybeicfnbaeigdtklwkrj35r4wtfppix732zromsadvgiu33mowah74yq.ipfs.dweb.link/treehouse.jpeg)
+
+In the link above, the CID `bafybeicfnbaeigdtklwkrj35r4wtfppix732zromsadvgiu33mowah74yq` points to an IPFS directory listing, which maps from the filename `treehouse.jpeg` to the CID for the image itself.
+
+Since the Web3.Storage client wraps your uploaded files in a directory by default, this is the most common kind of gateway link you're likely to need, and your users should get nice filenames when they download their content.
+
+However, the behavior is a bit different if you make a gateway link directly to the image CID:
+
+- [https://bafkreifvallbyfxnedeseuvkkswt5u3hbdb2fexcygbyjqy5a5rzmhrzei.ipfs.dweb.link/](https://bafkreifvallbyfxnedeseuvkkswt5u3hbdb2fexcygbyjqy5a5rzmhrzei.ipfs.dweb.link/)
+- [https://ipfs.io/ipfs/bafkreifvallbyfxnedeseuvkkswt5u3hbdb2fexcygbyjqy5a5rzmhrzei](https://ipfs.io/ipfs/bafkreifvallbyfxnedeseuvkkswt5u3hbdb2fexcygbyjqy5a5rzmhrzei)
+
+Both of the URLs above link directly to the CID of the image, without an associated filename. The first URL uses the recommended "subdomain" URL format for gateway links, while the second form uses a "path prefix" format that you may see in use elsewhere in the IPFS ecosystem. 
+
+Depending on which style of link you use, your browser will prompt you to save a file with a generic name like `download`, or with the CID as the filename.
+
+If you have such a link, you can override the default filename by adding a query string parameter to your link of the form `?filename=<desired-filename>`. For example, the following link will save as `treehouse.jpeg`, even though it links directly to the image by CID:
+
+[https://bafkreifvallbyfxnedeseuvkkswt5u3hbdb2fexcygbyjqy5a5rzmhrzei.ipfs.dweb.link/?filename=treehouse.jpeg](https://bafkreifvallbyfxnedeseuvkkswt5u3hbdb2fexcygbyjqy5a5rzmhrzei.ipfs.dweb.link/?filename=treehouse.jpeg)
+
 ## Using the Web3.Storage JS client
 
 The Web3.Storage JavaScript client provides a `get` method that allows you to retrieve any IPFS content using that content's [content identifier (CID)][ipfs-docs-cid].

--- a/docs/how-tos/troubleshooting.md
+++ b/docs/how-tos/troubleshooting.md
@@ -19,5 +19,13 @@ import { Web3Storage } from 'web3.storage/dist/bundle.esm.min.js'
 
 Content uploaded to Web3.Storage is persisted to Filecoin in batches, and newly uploaded content may take up to 48 hours to be stored on Filecoin. If more than 48 hours have elapsed since upload, and a [status request][howto-query] for your content returns no `deals` information, please [contact us][contact-us] so that we can investigate.
 
+
+
+## Files downloaded via an IPFS gateway have awkward names
+
+Depending on the type of URL used to request content from an IPFS HTTP gateway, some web browsers may save downloaded files with generic filenames like `download`, or they may use the CID of the content as the filename. See [Setting the filename for downloads via gateways][howto-retrieve-gateway-filenames] in the [Retrieval guide][howto-retrieve] to learn how to work around this issue.
+
 [howto-query]: ./query.md
+[howto-retrieve]: ./retrieve.md
+[howto-retrieve-gateway-filenames]: ./retrieve.md#setting-the-filename-for-downloads-via-gateways
 [contact-us]: ../community/help-and-support.md


### PR DESCRIPTION
This adds a bit to the retrieval guide about controlling the default filename for downloads when using gateway links. I also added a new troubleshooting entry that links to the new section.

closes #154 