### PR TITLE
add reference page for js util libs

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -99,7 +99,8 @@ module.exports = {
             collapsable: false,
             children: [
               ['https://docs.web3.storage/http-api.html','HTTP API reference'],
-              '/reference/client-library'
+              '/reference/client-library',
+              '/reference/js-utilities',
             ]
           },
           {

--- a/docs/reference/client-library.md
+++ b/docs/reference/client-library.md
@@ -9,7 +9,7 @@ To use the JavaScript client library for Web3.Storage, you must first [obtain a 
 
 The client library automatically packs your uploads into a content addressible archive (CAR) for uploading to the Web3.Storage service, which [stores](#store-files) data as blocks prefixed with the [_content identifier_ (CID)](../concepts/content-addressing.md#cids-location-independent-globally-unique-keys) derived from a cryptographic hash of the data. You can then use a file's CID to [retrieve](#retrieve-files) it.
 
-Most of the time, the client library is all you'll need to work with Web3.Storage. See the [JavaScript utility libraries page](./js-utilities.md) for some helpful packages that may help with advanced use cases.
+This page covers the core functionality of the JavaScript client. See the [JavaScript utility libraries page](./js-utilities.md) for some additional packages that may be useful when working with Web3.Storage.
 
 :::warning Minimum requirements
 While we recommend that you install the latest _stable_ version of the following software, you must have _at least_:

--- a/docs/reference/client-library.md
+++ b/docs/reference/client-library.md
@@ -9,6 +9,8 @@ To use the JavaScript client library for Web3.Storage, you must first [obtain a 
 
 The client library automatically packs your uploads into a content addressible archive (CAR) for uploading to the Web3.Storage service, which [stores](#store-files) data as blocks prefixed with the [_content identifier_ (CID)](../concepts/content-addressing.md#cids-location-independent-globally-unique-keys) derived from a cryptographic hash of the data. You can then use a file's CID to [retrieve](#retrieve-files) it.
 
+Most of the time, the client library is all you'll need to work with Web3.Storage. See the [JavaScript utility libraries page](./js-utilities.md) for some helpful packages that may help with advanced use cases.
+
 :::warning Minimum requirements
 While we recommend that you install the latest _stable_ version of the following software, you must have _at least_:
 

--- a/docs/reference/js-utilities.md
+++ b/docs/reference/js-utilities.md
@@ -1,0 +1,45 @@
+---
+title: JavaScript utility libraries
+description: Learn about some helpful utility libraries that make working with Web3.Storage easier.
+---
+
+# JavaScript utility libraries
+
+The Web3.Storage [JavaScript client library](./client-library.md) provides a simple interface for interacting with Web3.Storage. This page highlights some additional libraries that may be helpful when working with the client library, or when using the [HTTP API][reference-http-api] directly.
+
+## files-from-path
+
+The [files-from-path package][files-from-path] provides a simple way for Node.js users to load files from the filesystem into the `File` objects that the Web3.Storage client library likes to use.
+
+Here's a quick example:
+
+```js
+import { getFilesFromPath } from 'web3.storage'
+
+async function storeFiles(path = 'path/to/somewhere') {
+  const files = await getFilesFromPath(path)
+  for (const f of files) {
+    console.log(f)
+    // { name: '/path/to/me', stream: [Function: stream] }
+  }
+
+  const web3Storage = getStorageClient()
+  const cid = await web3storage.put(files)
+  console.log(`stored ${files.length} files. cid: ${cid}`)
+}
+```
+
+Note that if you're using the client library you don't need to install the `files-from-path` package seperately. Instead, just import the `getFilesFromPath` or `filesFromPath` functions from the `web3.storage` package.
+
+## ipfs-car
+
+The Web3.Storage API works with Content Archive (CAR) files, which package up [content addressed data][concepts-content-addressing] into a simple format for storage and transport. Internally, the client library uses the [ipfs-car package][ipfs-car] to create CARs from regular files before sending data to the API.
+
+If you prefer to work with CARs directly, see the how-to guide on [working with Content Archives][howto-car] for usage information for ipfs-car and information about other options.
+
+[concepts-content-addressing]: ../concepts/content-addressing.md
+[reference-http-api]: https://docs.web3.storage/http-api.html
+[howto-car]: ../how-to/work-with-car-files.md
+
+[files-from-path]: https://github.com/web3-storage/files-from-path
+[ipfs-car]: https://github.com/web3-storage/ipfs-car


### PR DESCRIPTION
This adds a new reference page for the js utility libraries `files-from-path` and `ipfs-car`. The new page just gives a little overview of each and links to the readme, etc.

Closes #128 