### PR TITLE
fix: match nav links order to match main website

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -68,8 +68,8 @@ module.exports = {
           }
         },
         nav: [
-          { text: 'About', link: `${MAIN_DOMAIN}/about/`, target: '_self' },
-          { text: 'Docs', link: '/' }
+          { text: 'Docs', link: '/' },
+          { text: 'About', link: `${MAIN_DOMAIN}/about/`, target: '_self' }
         ],
         sidebar: [
             '/',


### PR DESCRIPTION
### Main website

<img width="268" alt="image" src="https://user-images.githubusercontent.com/2353186/131819317-ca1bfc97-c6b9-4f90-a827-3fe966074f3c.png">

### Docs site

Before:

<img width="244" alt="image" src="https://user-images.githubusercontent.com/2353186/131819652-6ac030a5-e962-458f-8406-bb4c9249cb42.png">


After:

<img width="253" alt="image" src="https://user-images.githubusercontent.com/2353186/131819559-6feaa6ba-f6ec-460e-b1a4-227991f94620.png">

