### PR TITLE
fix: init countly at page load & track initial pageview

### DIFF
--- a/src/plugin/index.js
+++ b/src/plugin/index.js
@@ -3,24 +3,27 @@ const path = require('path')
 module.exports = function (context) {
   const {siteConfig} = context
   const {themeConfig} = siteConfig
-  const {countly} = themeConfig || {}
+  const {countly: countlyConfig} = themeConfig || {}
 
-  if (!countly) {
+  if (!countlyConfig) {
     throw new Error(
       `You need to specify "countly" object in "themeConfig" with "appKey" field in it to use this plugin.`,
     )
   }
 
-  const { appKey } = countly
+  const { appKey, countlyUrl } = countlyConfig
 
   if (!appKey) {
     throw new Error(
-      'You specified the "countly" object in "themeConfig" but the "appKey" field was missing. ' +
-        'Please ensure this is not a mistake.',
+      'You specified the "countly" object in "themeConfig" but the "appKey" field was missing.'
     )
   }
 
-  const countlyConfigStr = JSON.stringify(countly)
+  if (!countlyUrl) {
+    throw new Error(
+      'You specified the "countly" object in "themeConfig" but the "countlyUrl" field was missing.'
+    )
+  }
 
   const isProd = process.env.NODE_ENV === 'production'
   const enabled = isProd || process.env.DEBUG_ENABLE_COUNTLY
@@ -40,12 +43,6 @@ module.exports = function (context) {
         headTags: [
           {
             tagName: 'script',
-            innerHTML: `
-            window._countlyConfig = ${countlyConfigStr};
-            `
-          },
-          {
-            tagName: 'script',
             attributes: {
               src: 'https://cdn.jsdelivr.net/npm/countly-sdk-web@latest/lib/countly.min.js',
             }
@@ -59,16 +56,11 @@ module.exports = function (context) {
               if (event.target.readyState !== "complete") {
                 return
               }
-              if (!window._countlyConfig) {
-                console.warn('no countly configuration found. analytics disabled')
-                return
-              }
-              const { appKey, countlyUrl } = window._countlyConfig
               
-              console.log('initializing countly sdk with url: ', countlyUrl)
+              console.log('initializing countly sdk with url: ${countlyUrl}')
               Countly.init({
-                app_key: appKey,
-                url: countlyUrl,
+                app_key: '${appKey}',
+                url: '${countlyUrl}',
                 app_version: "1.0",
                 debug: ${(!isProd).toString()}
               })

--- a/src/plugin/index.js
+++ b/src/plugin/index.js
@@ -43,6 +43,43 @@ module.exports = function (context) {
             innerHTML: `
             window._countlyConfig = ${countlyConfigStr};
             `
+          },
+          {
+            tagName: 'script',
+            attributes: {
+              src: 'https://cdn.jsdelivr.net/npm/countly-sdk-web@latest/lib/countly.min.js',
+            }
+          }
+        ],
+        postBodyTags: [
+          {
+            tagName: 'script',
+            innerHTML: `
+            document.addEventListener('readystatechange', event => {
+              if (event.target.readyState !== "complete") {
+                return
+              }
+              if (!window._countlyConfig) {
+                console.warn('no countly configuration found. analytics disabled')
+                return
+              }
+              const { appKey, countlyUrl } = window._countlyConfig
+              
+              console.log('initializing countly sdk with url: ', countlyUrl)
+              Countly.init({
+                app_key: appKey,
+                url: countlyUrl,
+                app_version: "1.0",
+                debug: ${(!isProd).toString()}
+              })
+
+              Countly.track_sessions()
+              Countly.track_clicks()
+              Countly.track_scrolls()
+
+              Countly.track_pageview(window.location.pathname)
+             });
+            `
           }
         ]
       }

--- a/src/util/countly.js
+++ b/src/util/countly.js
@@ -1,5 +1,3 @@
-import countly from 'countly-sdk-web'
-
 const debug = process.env.NODE_ENV !== 'production'
 
 export const events = {
@@ -14,36 +12,12 @@ export const events = {
 }
 
 let ready = false
-let warnedAboutMissingCountly = false
 export function init () {
-  if (ready || typeof window === 'undefined') {
+  if (ready || typeof window === 'undefined' || typeof Countly == 'undefined') {
     return
   }
 
-  if (!window._countlyConfig) {
-    if (!warnedAboutMissingCountly) {
-      console.warn('no countly configuration found. analytics disabled')
-      warnedAboutMissingCountly = true
-    }
-    return
-  }
-
-  const { appKey, url } = window._countlyConfig
-
-  countly.init({
-    app_key: appKey,
-    app_version: "1.0",
-    url,
-    debug,
-  });
-  
-  countly.track_sessions();
-  countly.track_pageview();
-  countly.track_clicks();
-  countly.track_links();
-  countly.track_scrolls();
-
-  // Track other built-in docusaurus links
+  // Track built-in docusaurus links
   document.addEventListener('click', ({ target }) => {
     if (!target.tagName) {
       return
@@ -99,13 +73,12 @@ export function trackEvent (event, data = {}) {
     }
   }
 
-  debug && console.info('[countly]', 'trackEvent()', event, data)
-
-  if (typeof window === 'undefined') {
+  if (typeof window === 'undefined' || typeof Countly === 'undefined') {
     return
   }
-
-  countly.add_event({
+                
+  debug && console.info('[countly]', 'trackEvent()', event, data)
+  Countly.add_event({
     key: event,
     segmentation: data
   })
@@ -121,8 +94,12 @@ export function trackPageView (path) {
     }
   }
 
+  if (typeof window === 'undefined' || typeof Countly === 'undefined') {
+    return
+  }
+
   debug && console.info('[countly]', 'trackPageView()', path)
-  countly.track_pageview(path)
+  Countly.track_pageview(path)
 }
 
 export default {


### PR DESCRIPTION
This changes the way we load the countly SDK.

Quick recap of how the countly integration works, since I don't think it's documented well elsewhere. 

Basically, to hook into docusaurus's router and get notified on route changes, I had to write a custom docusaurus plugin and use the `onRouteUpdate` hook (described in this [SO answer](https://stackoverflow.com/a/63981821/1292992)). Unfortunately, it seems this hook doesn't fire for the initial page load.

This changes the plugin to initialize the countly sdk in a script tag that gets injected into every page - because this script executes at the global scope and can't `import` stuff from the bundle, it loads the countly SDK from a CDN into the global `window.Countly` object instead of importing the npm package.

I tested locally with `COUNTLY_KEY=<production-key> DEBUG_ENABLE_COUNTLY=true npm run start` and get what looks like success:

<img width="1051" alt="Screen Shot 2021-11-15 at 1 26 59 PM" src="https://user-images.githubusercontent.com/678715/141834870-44c9b251-ead4-4957-b8dc-585760ea9d57.png">


Closes #207 