### PR TITLE
fix: broken tab headers in js client reference

### DIFF
--- a/docs/reference/js-client-library.md
+++ b/docs/reference/js-client-library.md
@@ -196,13 +196,13 @@ Returns `undefined` if there are no matches for the given CID.
 If found, the method returns a `Web3Response` object, which extends the [Fetch API response object](https://developer.mozilla.org/en-US/docs/Web/API/Response) to add two iterator methods unique to the Web3.Storage client library: `files()` and `unixFsIterator()`.
 
 <!--tabs-->
-#### Using `File` objects
+#### Using File objects
 
 Calling the `files()` method returns your requested files as an `Array<Web3File>` object, which is an iterable collection of `Web3File` objects. Each object represents a file that was uploaded in the CAR with the supplied CID.
 
 The `Web3File` type extends [the generic JavaScript `File` type](https://developer.mozilla.org/en-US/docs/Web/API/File), adding a `string` property for the CID of the given file named `cid`, as shown in the example below. This is different from the CID of the CAR that contains the file, which you specified when calling `get()`.
 
-#### Using `UnixFS` objects
+#### Using UnixFS objects
 
 In addition to the `files()` method, you can also use the `unixFsIterator()` method. This returns your requested files as a  `AsyncIterable<UnixFS>` object, which is an iterable collection of [`UnixFS`](https://github.com/ipfs/js-ipfs-unixfs/blob/master/packages/ipfs-unixfs/README.md) objects. Each object represents a file that was uploaded in the CAR with the supplied CID.
 


### PR DESCRIPTION
Looks like the backtics were confusing the markdown parser for the tab plugin.

closes #211