### PR TITLE
chore: add info about rate limits to http docs & troubleshooting

### DIFF
--- a/docs/how-tos/troubleshooting.md
+++ b/docs/how-tos/troubleshooting.md
@@ -32,8 +32,15 @@ By default, the CID returned when uploading files to Web3.Storage will be wrappe
 
 See the [Directory Wrapping section](./store.md#directory-wrapping) of the [Storage guide][howto-store] for more information about working with directory CIDs and instructions on changing the default behavior.
 
+## I get a 429 "Too many requests" error when using the [HTTP API][reference-http]
+
+The HTTP API imposes rate limits to ensure that a single user cannot overwhelm the service with a flood of requests.
+
+Rate limits are imposed when more than 30 requests from the same API token are received within a ten second window. To avoid being limited, try to throttle your requests to stay within this limit. Alternatively, you can respond to a 429 status by backing off for a few seconds and retrying the request.
+
 [howto-store]: ./store.md
 [howto-query]: ./query.md
 [howto-retrieve]: ./retrieve.md
 [howto-retrieve-gateway-filenames]: ./retrieve.md#setting-the-filename-for-downloads-via-gateways
+[reference-http]: ../reference/http-api/
 [contact-us]: ../community/help-and-support.md

--- a/static/schema.yml
+++ b/static/schema.yml
@@ -10,6 +10,10 @@ info:
 
     The main public API endpoint URL for Web3.Storage is `https://api.web3.storage`. All endpoints described in this document should be made relative to this root URL. For example, to post to the `/car` endpoint, send your request to `https://api.web3.storage/car`.
     
+    ### Rate limits
+
+    This API imposes rate limits to ensure quality of service. You may receive a 429 "Too many requests" error if you make more than 30 requests with the same API token within a ten second window. Upon receiving a response with a 429 status, clients should retry the failed request after a small delay. To avoid 429 responses, you may wish to implement client-side request throttling to stay within the limits.
+
   version: '1.0'
 
 servers:


### PR DESCRIPTION
This adds a note about rate limits to the HTTP api spec and an entry to the troubleshooting section.

closes https://github.com/web3-storage/web3.storage/issues/269