### PR TITLE
Fix the `storeWithProgress` example

### DIFF
--- a/code-snippets/how-to/index.js
+++ b/code-snippets/how-to/index.js
@@ -40,8 +40,8 @@ async function storeWithProgress(files) {
 
   const onStoredChunk = size => {
     uploaded += size
-    const pct = totalSize / uploaded
-    console.log(`Uploading... ${pct.toFixed(2)}% complete`)
+    const pct = uploaded / totalSize
+    console.log(`Uploading... ${Math.min(pct * 100, 100).toFixed(2)}% complete`)
   }
 
   // makeStorageClient returns an authorized Web3.Storage client instance


### PR DESCRIPTION
This PR fixes two bugs in the `storeWithProgress` example in the docs:
1. The percentage was calculated incorrectly: the two values were flipped, meaning the percentage descended over time.
2. The percentage could reach values > 100%, so I added `Math.min()` to cap it at a hundred.